### PR TITLE
Further improvements to optimizer.

### DIFF
--- a/builder/options.go
+++ b/builder/options.go
@@ -14,4 +14,5 @@ type Options struct {
 	BuildTags         []string
 	CTypeNames        bool
 	NumJobs           int
+	Optimization      string
 }

--- a/cmd/sigoc/main.go
+++ b/cmd/sigoc/main.go
@@ -76,7 +76,6 @@ func main() {
 
 func build(args []string) {
 	buildFlags := flag.NewFlagSet("build", flag.ExitOnError)
-	buildFlags.Usage = buildUsage
 
 	// Add build args
 	output := buildFlags.String("o", ".", "output file")
@@ -84,9 +83,10 @@ func build(args []string) {
 	debug := buildFlags.Bool("g", false, "generate debug information")
 	dumpOnVerError := buildFlags.Bool("dump-verify", false, "dump IR upon verification error")
 	dumpIR := buildFlags.Bool("dump-ir", false, "dump the IR")
-	tags := buildFlags.String("tags", "", "Build tags")
-	useCTypeNames := buildFlags.Bool("ctypenames", false, "Use C type names for primitives in debug information")
+	tags := buildFlags.String("tags", "", "build tags")
+	useCTypeNames := buildFlags.Bool("ctypenames", false, "use C type names for primitives in debug information")
 	numJobs := buildFlags.Int("j", runtime.NumCPU(), "number of concurrent builds")
+	optimize := buildFlags.String("O", "0", "optimization level")
 
 	// TODO: Implement dependency files for smarter make builds
 	//createDependencyFiles := flags.Bool("MD", false, "create dependency files for Make")
@@ -113,6 +113,7 @@ func build(args []string) {
 		BuildTags:         strings.Split(*tags, ","),
 		CTypeNames:        *useCTypeNames,
 		NumJobs:           *numJobs,
+		Optimization:      *optimize,
 	}
 
 	if len(buildFlags.Args()) == 0 {

--- a/compiler/binop.go
+++ b/compiler/binop.go
@@ -116,9 +116,9 @@ func (c *Compiler) createBinOp(ctx context.Context, expr *ssa.BinOp) (value llvm
 		} else if typeInfo&types.IsString != 0 {
 			value = c.createRuntimeCall(ctx, "stringCompare", []llvm.LLVMValueRef{c.addressOf(ctx, x), c.addressOf(ctx, y)})
 		} else if typeInfo&types.IsFloat != 0 {
-			value = llvm.BuildFCmp(c.builder, llvm.LLVMRealOEQ, x, y, "")
+			value = llvm.BuildFCmp(c.builder, llvm.RealOEQ, x, y, "")
 		} else {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntEQ, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntEQ, x, y, "")
 		}
 	case token.NEQ:
 		if types.IsInterface(expr.X.Type()) || types.IsInterface(expr.Y.Type()) {
@@ -133,41 +133,41 @@ func (c *Compiler) createBinOp(ctx context.Context, expr *ssa.BinOp) (value llvm
 				value = llvm.ConstInt(llvm.Int1TypeInContext(c.currentContext(ctx)), 1, false)
 			}
 		} else if typeInfo&types.IsFloat != 0 {
-			value = llvm.BuildFCmp(c.builder, llvm.LLVMRealONE, x, y, "")
+			value = llvm.BuildFCmp(c.builder, llvm.RealONE, x, y, "")
 		} else {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntNE, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntNE, x, y, "")
 		}
 	case token.LSS:
 		if typeInfo&types.IsFloat != 0 {
-			value = llvm.BuildFCmp(c.builder, llvm.LLVMRealOLT, x, y, "")
+			value = llvm.BuildFCmp(c.builder, llvm.RealOLT, x, y, "")
 		} else if typeInfo&types.IsUnsigned != 0 {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntULT, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntULT, x, y, "")
 		} else {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntSLT, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntSLT, x, y, "")
 		}
 	case token.LEQ:
 		if typeInfo&types.IsFloat != 0 {
-			value = llvm.BuildFCmp(c.builder, llvm.LLVMRealOLE, x, y, "")
+			value = llvm.BuildFCmp(c.builder, llvm.RealOLE, x, y, "")
 		} else if typeInfo&types.IsUnsigned != 0 {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntULE, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntULE, x, y, "")
 		} else {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntSLE, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntSLE, x, y, "")
 		}
 	case token.GTR:
 		if typeInfo&types.IsFloat != 0 {
-			value = llvm.BuildFCmp(c.builder, llvm.LLVMRealOGT, x, y, "")
+			value = llvm.BuildFCmp(c.builder, llvm.RealOGT, x, y, "")
 		} else if typeInfo&types.IsUnsigned != 0 {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntUGT, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntUGT, x, y, "")
 		} else {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntSGT, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntSGT, x, y, "")
 		}
 	case token.GEQ:
 		if typeInfo&types.IsFloat != 0 {
-			value = llvm.BuildFCmp(c.builder, llvm.LLVMRealOGE, x, y, "")
+			value = llvm.BuildFCmp(c.builder, llvm.RealOGE, x, y, "")
 		} else if typeInfo&types.IsUnsigned != 0 {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntUGE, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntUGE, x, y, "")
 		} else {
-			value = llvm.BuildICmp(c.builder, llvm.LLVMIntSGE, x, y, "")
+			value = llvm.BuildICmp(c.builder, llvm.IntSGE, x, y, "")
 		}
 	}
 

--- a/compiler/testdata/schedulertest/main.go
+++ b/compiler/testdata/schedulertest/main.go
@@ -11,12 +11,14 @@ import (
 	"time"
 
 	mcu "runtime/arm/cortexm/sam/atsamx51"
+	"runtime/arm/cortexm/sam/atsamx51/spi"
 	"runtime/arm/cortexm/sam/atsamx51/uart"
 	_ "runtime/arm/cortexm/sam/chip/atsame51g19a"
 )
 
 var (
 	UART = uart.UART5
+	SPI  = spi.SPI0
 )
 
 func initMCU() {
@@ -30,6 +32,22 @@ func initMCU() {
 		NumStopBits:     1,
 		ReceiveEnabled:  true,
 		TransmitEnabled: true,
+	})
+
+	SPI.Configure(spi.Config{
+		DI:             mcu.PA04,
+		DO:             mcu.PA07,
+		SCK:            mcu.PA05,
+		CS:             mcu.PA06,
+		BaudHz:         10_000_000,
+		CharacterSize:  8,
+		DataOrder:      spi.MSB,
+		Form:           spi.Frame,
+		HardwareSelect: true,
+		Mode:           spi.HostMode,
+		Phase:          spi.LeadingEdge,
+		Polarity:       spi.IdleLow,
+		ReceiveEnabled: true,
 	})
 }
 

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -52,9 +52,9 @@ func (c *Compiler) createType(ctx context.Context, typ types.Type) *Type {
 			panic("Not implemented")
 		case types.Complex128:
 			panic("Not implemented")
-		case types.String:
+		case types.String, types.UntypedString:
 			result.valueType = llvm.GetTypeByName2(c.currentContext(ctx), "string")
-		case types.Bool:
+		case types.Bool, types.UntypedBool:
 			result.valueType = llvm.Int1TypeInContext(c.currentContext(ctx))
 		default:
 			panic("encountered unknown basic type")

--- a/llvm/enums.go
+++ b/llvm/enums.go
@@ -1,0 +1,306 @@
+package llvm
+
+const (
+	LLVMRet LLVMOpcode = iota + 1
+	LLVMBr
+	LLVMSwitch
+	LLVMIndirectBr
+	LLVMInvoke
+	LLVMUnreachable
+	LLVMCallBr
+	LLVMFNeg
+	LLVMAdd
+	LLVMFAdd
+	LLVMSub
+	LLVMFSub
+	LLVMMul
+	LLVMFMul
+	LLVMUDiv
+	LLVMSDiv
+	LLVMFDiv
+	LLVMURem
+	LLVMSRem
+	LLVMFRem
+	LLVMShl
+	LLVMLShr
+	LLVMAShr
+	LLVMAnd
+	LLVMOr
+	LLVMXor
+	LLVMAlloca
+	LLVMLoad
+	LLVMStore
+	LLVMGetElementPtr
+	LLVMTrunc
+	LLVMZExt
+	LLVMSExt
+	LLVMFPToUI
+	LLVMFPToSI
+	LLVMUIToFP
+	LLVMSIToFP
+	LLVMFPTrunc
+	LLVMFPExt
+	LLVMPtrToInt
+	LLVMIntToPtr
+	LLVMBitCast
+	LLVMAddrSpaceCast
+	LLVMICmp
+	LLVMFCmp
+	LLVMPHI
+	LLVMCall
+	LLVMSelect
+	LLVMUserOp1
+	LLVMUserOp2
+	LLVMVAArg
+	LLVMExtractElement
+	LLVMInsertElement
+	LLVMShuffleVector
+	LLVMExtractValue
+	LLVMInsertValue
+	LLVMFreeze
+	LLVMFence
+	LLVMAtomicCmpXchg
+	LLVMAtomicRMW
+	LLVMResume
+	LLVMLandingPad
+	LLVMCleanupRet
+	LLVMCatchRet
+	LLVMCatchPad
+	LLVMCleanupPad
+	LLVMCatchSwitch
+)
+
+const (
+	VoidTypeKind LLVMTypeKind = iota
+	HalfTypeKind
+	FloatTypeKind
+	DoubleTypeKind
+	X86_FP80TypeKind
+	FP128TypeKind
+	PPC_FP128TypeKind
+	LabelTypeKind
+	IntegerTypeKind
+	FunctionTypeKind
+	StructTypeKind
+	ArrayTypeKind
+	PointerTypeKind
+	VectorTypeKind
+	MetadataTypeKind
+	X86_MMXTypeKind
+	TokenTypeKind
+	ScalableVectorTypeKind
+	BFloatTypeKind
+	X86_AMXTypeKind
+	TargetExtTypeKind
+)
+
+const (
+	ExternalLinkage LLVMLinkage = iota // Externally visible function.
+	AvailableExternallyLinkage
+	LinkOnceAnyLinkage         // Keep one copy of function when linking (inline)
+	LinkOnceODRLinkage         // Same, but only replaced by something equivalent.
+	LinkOnceODRAutoHideLinkage // Obsolete.
+	WeakAnyLinkage             // Keep one copy of function when linking (weak)
+	WeakODRLinkage             // Same, but only replaced by something equivalent.
+	AppendingLinkage           // Special purpose, only applies to global arrays.
+	InternalLinkage            // Rename collisions when linking (static functions)
+	PrivateLinkage             // Like Internal, but omit from symbol table.
+	DLLImportLinkage           // Obsolete.
+	DLLExportLinkage           // Obsolete.
+	ExternalWeakLinkage        // ExternalWeak linkage description.
+	GhostLinkage               // Obsolete.
+	CommonLinkage              // Tentative definitions.
+	LinkerPrivateLinkage       // Like Private, but linker removes.
+	LinkerPrivateWeakLinkage   // Like LinkerPrivate, but is weak.
+)
+
+const (
+	DefaultVisibility   LLVMVisibility = iota // The GV is visible.
+	HiddenVisibility                          // The GV is hidden.
+	ProtectedVisibility                       // The GV is protected.
+)
+
+const (
+	NoUnnamedAddr     LLVMUnnamedAddr = iota // Address of the GV is significant.
+	LocalUnnamedAddr                         // Address of the GV is locally insignificant.
+	GlobalUnnamedAddr                        // Address of the GV is globally insignificant.
+)
+
+const (
+	DefaultStorageClass   LLVMDLLStorageClass = iota
+	DLLImportStorageClass                     // Function to be imported from DLL.
+	DLLExportStorageClass                     // Function to be accessible from DLL.
+)
+
+type LLVMCallConv uint
+
+const (
+	CCallConv    LLVMCallConv = iota
+	FastCallConv LLVMCallConv = iota + 7
+	ColdCallConv
+	GHCCallConv
+	HiPECallConv
+	WebKitJSCallConv
+	AnyRegCallConv
+	PreserveMostCallConv
+	PreserveAllCallConv
+	SwiftCallConv
+	CXXFASTTLSCallConv
+	X86StdcallCallConv LLVMCallConv = iota + 53
+	X86FastcallCallConv
+	ARMAPCSCallConv
+	ARMAAPCSCallConv
+	ARMAAPCSVFPCallConv
+	MSP430INTRCallConv
+	X86ThisCallCallConv
+	PTXKernelCallConv
+	PTXDeviceCallConv
+	SPIRFUNCCallConv LLVMCallConv = iota + 55
+	SPIRKERNELCallConv
+	IntelOCLBICallConv
+	X8664SysVCallConv
+	Win64CallConv
+	X86VectorCallCallConv
+	HHVMCallConv
+	HHVMCCallConv
+	X86INTRCallConv
+	AVRINTRCallConv
+	AVRSIGNALCallConv
+	AVRBUILTINCallConv
+	AMDGPUVSCallConv
+	AMDGPUGSCallConv
+	AMDGPUPSCallConv
+	AMDGPUCSCallConv
+	AMDGPUKERNELCallConv
+	X86RegCallCallConv
+	AMDGPUHSCallConv
+	MSP430BUILTINCallConv
+	AMDGPULSCallConv
+	AMDGPUESCallConv
+)
+
+const (
+	ArgumentValueKind LLVMValueKind = iota
+	BasicBlockValueKind
+	MemoryUseValueKind
+	MemoryDefValueKind
+	MemoryPhiValueKind
+	FunctionValueKind
+	GlobalAliasValueKind
+	GlobalIFuncValueKind
+	GlobalVariableValueKind
+	BlockAddressValueKind
+	ConstantExprValueKind
+	ConstantArrayValueKind
+	ConstantStructValueKind
+	ConstantVectorValueKind
+	UndefValueValueKind
+	ConstantAggregateZeroValueKind
+	ConstantDataArrayValueKind
+	ConstantDataVectorValueKind
+	ConstantIntValueKind
+	ConstantFPValueKind
+	ConstantPointerNullValueKind
+	ConstantTokenNoneValueKind
+	MetadataAsValueValueKind
+	InlineAsmValueKind
+	InstructionValueKind
+	PoisonValueValueKind
+	ConstantTargetNoneValueKind
+)
+
+const (
+	IntEQ  LLVMIntPredicate = iota + 32 // equal
+	IntNE                               // not equal
+	IntUGT                              // unsigned greater than
+	IntUGE                              // unsigned greater or equal
+	IntULT                              // unsigned less than
+	IntULE                              // unsigned less or equal
+	IntSGT                              // signed greater than
+	IntSGE                              // signed greater or equal
+	IntSLT                              // signed less than
+	IntSLE                              // signed less or equal
+)
+
+const (
+	RealPredicateFalse = iota // Always false (always folded)
+	RealOEQ                   // True if ordered and equal
+	RealOGT                   // True if ordered and greater than
+	RealOGE                   // True if ordered and greater than or equal
+	RealOLT                   // True if ordered and less than
+	RealOLE                   // True if ordered and less than or equal
+	RealONE                   // True if ordered and operands are unequal
+	RealORD                   // True if ordered (no nans)
+	RealUNO                   // True if unordered: isnan(X) | isnan(Y)
+	RealUEQ                   // True if unordered or equal
+	RealUGT                   // True if unordered or greater than
+	RealUGE                   // True if unordered, greater than, or equal
+	RealULT                   // True if unordered or less than
+	RealULE                   // True if unordered, less than, or equal
+	RealUNE                   // True if unordered or not equal
+	RealPredicateTrue         // Always true (always folded)
+)
+
+type LLVMLandingPadClauseTy uint
+
+const (
+	LandingPadCatch LLVMLandingPadClauseTy = iota
+	LandingPadFilter
+)
+
+const (
+	NotThreadLocal LLVMThreadLocalMode = iota
+	GeneralDynamicTLSModel
+	LocalDynamicTLSModel
+	InitialExecTLSModel
+	LocalExecTLSModel
+)
+
+const (
+	AtomicOrderingNotAtomic              LLVMAtomicOrdering = iota     // A load or store which is not atomic.
+	AtomicOrderingUnordered                                            // Lowest level of atomicity, guarantees somewhat sane results, lock free.
+	AtomicOrderingMonotonic                                            // guarantees that if you take all the operations affecting a specific address, a consistent ordering exists
+	AtomicOrderingAcquire                LLVMAtomicOrdering = iota + 1 // Acquire provides a barrier of the sort necessary to acquire a lock to access other memory with normal loads and stores.
+	AtomicOrderingRelease                                              // Release is similar to Acquire, but with a barrier of the sort necessary to release a lock.
+	AtomicOrderingAcquireRelease                                       // provides both an Acquire and a Release barrier (for fences and operations which both read and write memory).
+	AtomicOrderingSequentiallyConsistent                               // provides Acquire semantics for loads and Release semantics for stores. Additionally, it guarantees that a total ordering exists between all SequentiallyConsistent operations.
+)
+
+const (
+	AtomicRMWBinOpXchg LLVMAtomicRMWBinOp = iota // Set the new value and return the one old.
+	AtomicRMWBinOpAdd                            // Add a value and return the old one.
+	AtomicRMWBinOpSub                            // Subtract a value and return the old one.
+	AtomicRMWBinOpAnd                            // And a value and return the old one.
+	AtomicRMWBinOpNand                           // Not-And a value and return the old one.
+	AtomicRMWBinOpOr                             // OR a value and return the old one.
+	AtomicRMWBinOpXor                            // Xor a value and return the old one.
+	AtomicRMWBinOpMax                            // Sets the value if it's greater than the original using a signed comparison and return the old one.
+	AtomicRMWBinOpMin                            // Sets the value if it's Smaller than the original using a signed comparison and return the old one.
+	AtomicRMWBinOpUMax                           // Sets the value if it's greater than the original using an unsigned comparison and return the old one.
+	AtomicRMWBinOpUMin                           // Sets the value if it's greater than the original using an unsigned comparison and return the old one.
+	AtomicRMWBinOpFAdd                           // Add a floating point value and return the old one.
+	AtomicRMWBinOpFSub                           // Subtract a floating point value and return the old one.
+	AtomicRMWBinOpFMax                           // Sets the value if it's greater than the original using an floating point comparison and return the old one.
+	AtomicRMWBinOpFMin                           // Sets the value if it's smaller than the original using an floating point comparison and return the old one.
+)
+
+const (
+	DSError LLVMDiagnosticSeverity = iota
+	DSWarning
+	DSRemark
+	DSNote
+)
+
+const (
+	InlineAsmDialectATT LLVMInlineAsmDialect = iota
+	InlineAsmDialectIntel
+)
+
+const (
+	ModuleFlagBehaviorError        LLVMModuleFlagBehavior = iota // Emits an error if two values disagree, otherwise the resulting value is that of the operands.
+	ModuleFlagBehaviorWarning                                    // Emits a warning if two values disagree. The result value will be the operand for the flag from the first module being linked.
+	ModuleFlagBehaviorRequire                                    // Adds a requirement that another module flag be present and have a specified value after linking is performed.
+	ModuleFlagBehaviorOverride                                   // Uses the specified value, regardless of the behavior or value of the other module.
+	ModuleFlagBehaviorAppend                                     // Appends the two values, which are required to be metadata nodes.
+	ModuleFlagBehaviorAppendUnique                               // Appends the two values, which are required to be metadata nodes.
+)

--- a/llvm/llvm.i
+++ b/llvm/llvm.i
@@ -81,18 +81,10 @@
 #include "llvm-c/Transforms/Vectorize.h"
 %}
 
-%typemap(gotype) LLVMTypeKind "LLVMTypeKind"
-%typemap(gotype) LLVMIntPredicate "LLVMIntPredicate"
-%typemap(gotype) LLVMRealPredicate "LLVMRealPredicate"
-
 %{
 typedef int                                     LLVMBool;
 typedef unsigned                                LLVMDWARFTypeEncoding;
 %}
-
-%ignore LLVMTypeKind;
-%ignore LLVMIntPredicate;
-%ignore LLVMRealPredicate;
 
 // Apply bool typemaps to LLVMBool
 %apply bool { LLVMBool };
@@ -124,9 +116,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Directory, size_t DirectoryLen),
                     (const char *UniqueId, size_t UniqueIdLen),
                     (const char *LinkageName, size_t LinkageNameLen),
-                    (const char *Flags, size_t FlagsLen),
                     (const char *Producer, size_t ProducerLen),
-                    (const char *SplitName, size_t SplitNameLen),
                     (const char *SysRoot, size_t SysRootLen),
                     (const char *SDK, size_t SDKLen),
                     (const char *Str, unsigned Length),
@@ -135,7 +125,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
 
 {
     $1 = $input;
@@ -147,9 +140,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Directory, size_t DirectoryLen),
                     (const char *UniqueId, size_t UniqueIdLen),
                     (const char *LinkageName, size_t LinkageNameLen),
-                    (const char *Flags, size_t FlagsLen),
                     (const char *Producer, size_t ProducerLen),
-                    (const char *SplitName, size_t SplitNameLen),
                     (const char *SysRoot, size_t SysRootLen),
                     (const char *SDK, size_t SDKLen),
                     (const char *Str, unsigned Length),
@@ -158,7 +149,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
 {
     $result = $1;
 }
@@ -168,9 +162,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Directory, size_t DirectoryLen),
                     (const char *UniqueId, size_t UniqueIdLen),
                     (const char *LinkageName, size_t LinkageNameLen),
-                    (const char *Flags, size_t FlagsLen),
                     (const char *Producer, size_t ProducerLen),
-                    (const char *SplitName, size_t SplitNameLen),
                     (const char *SysRoot, size_t SysRootLen),
                     (const char *SDK, size_t SDKLen),
                     (const char *Str, unsigned Length),
@@ -179,7 +171,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
 {
     free($input);
 }
@@ -200,7 +195,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
                     "*C.char";
 
 %typemap(gotype)    (const char *Name, size_t NameLen),
@@ -208,9 +206,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Directory, size_t DirectoryLen),
                     (const char *UniqueId, size_t UniqueIdLen),
                     (const char *LinkageName, size_t LinkageNameLen),
-                    (const char *Flags, size_t FlagsLen),
                     (const char *Producer, size_t ProducerLen)
-                    (const char *SplitName, size_t SplitNameLen),
                     (const char *SysRoot, size_t SysRootLen),
                     (const char *SDK, size_t SDKLen),
                     (const char *Str, unsigned Length),
@@ -219,7 +215,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
                     "string";
 
 %typemap(goin)      (const char *Name, size_t NameLen),
@@ -227,9 +226,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Directory, size_t DirectoryLen),
                     (const char *UniqueId, size_t UniqueIdLen),
                     (const char *LinkageName, size_t LinkageNameLen),
-                    (const char *Flags, size_t FlagsLen),
                     (const char *Producer, size_t ProducerLen),
-                    (const char *SplitName, size_t SplitNameLen),
                     (const char *SysRoot, size_t SysRootLen),
                     (const char *SDK, size_t SDKLen),
                     (const char *Str, unsigned Length),
@@ -238,7 +235,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
 {
     $result = C.CString($1)
 }
@@ -248,9 +248,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Directory, size_t DirectoryLen),
                     (const char *UniqueId, size_t UniqueIdLen),
                     (const char *LinkageName, size_t LinkageNameLen),
-                    (const char *Flags, size_t FlagsLen),
                     (const char *Producer, size_t ProducerLen),
-                    (const char *SplitName, size_t SplitNameLen),
                     (const char *SysRoot, size_t SysRootLen),
                     (const char *SDK, size_t SDKLen),
                     (const char *Str, unsigned Length),
@@ -259,7 +257,10 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
                     (const char *Str, size_t SLen),
                     (const char *Name, unsigned SLen),
                     (const char *Name, size_t SLen),
-                    (const char *Linkage, size_t LinkLen)
+                    (const char *Linkage, size_t LinkLen),
+                    (const char *Flags, size_t FlagsLen),
+                    (const char *SplitName, size_t SplitNameLen),
+                    (const char *Key, size_t KeyLen)
 {
     $result = C.GoString($1)
 }
@@ -410,7 +411,7 @@ typedef unsigned                                LLVMDWARFTypeEncoding;
     $2 = ($2_type)$input.len;
 }
 
-%define LLVM_TYPEMAP(OPAQUE, TYPE)
+%define LLVM_TYPEMAP(TYPE)
 %typemap(gotype) TYPE "TYPE";
 %typemap(gotype) TYPE * "*TYPE";
 %typemap(imtype) TYPE "C.TYPE"
@@ -423,43 +424,61 @@ type TYPE C.TYPE
 %}
 %enddef
 
-LLVM_TYPEMAP(LLVMOpaqueContext, LLVMContextRef)
-LLVM_TYPEMAP(LLVMOpaqueModule, LLVMModuleRef)
-LLVM_TYPEMAP(LLVMOpaqueType, LLVMTypeRef)
-LLVM_TYPEMAP(LLVMOpaqueValue, LLVMValueRef)
-LLVM_TYPEMAP(LLVMOpaqueBasicBlock, LLVMBasicBlockRef)
-LLVM_TYPEMAP(LLVMOpaqueMetadata, LLVMMetadataRef)
-LLVM_TYPEMAP(LLVMOpaqueNamedMDNode, LLVMNamedMDNodeRef)
-LLVM_TYPEMAP(LLVMOpaqueValueMetadataEntry, LLVMValueMetadataEntry)
-LLVM_TYPEMAP(LLVMOpaqueBuilder, LLVMBuilderRef)
-LLVM_TYPEMAP(LLVMOpaqueDIBuilder, LLVMDIBuilderRef)
-LLVM_TYPEMAP(LLVMOpaqueModuleProvide, LLVMModuleProviderRef)
-LLVM_TYPEMAP(LLVMOpaquePassManager, LLVMPassManagerRef)
-LLVM_TYPEMAP(LLVMOpaquePassRegistry, LLVMPassRegistryRef)
-LLVM_TYPEMAP(LLVMOpaqueUse, LLVMUseRef)
-LLVM_TYPEMAP(LLVMOpaqueAttributeRef, LLVMAttributeRef)
-LLVM_TYPEMAP(LLVMOpaqueDiagnosticInfo, LLVMDiagnosticInfoRef)
-LLVM_TYPEMAP(LLVMComdat, LLVMComdatRef)
-LLVM_TYPEMAP(LLVMOpaqueModuleFlagEntry, LLVMModuleFlagEntry)
-LLVM_TYPEMAP(LLVMOpaqueJITEventListener, LLVMJITEventListenerRef)
-LLVM_TYPEMAP(LLVMOpaqueBinary, LLVMBinaryRef)
-LLVM_TYPEMAP(LLVMOpaqueTargetMachine, LLVMTargetMachineRef)
-LLVM_TYPEMAP(LLVMOpaqueTarget, LLVMTargetRef)
-LLVM_TYPEMAP(LLVMOpaqueTargetData, LLVMTargetDataRef)
-LLVM_TYPEMAP(LLVMOpaqueTargetLibraryInfotData, LLVMTargetLibraryInfoRef)
-LLVM_TYPEMAP(LLVMOpaquePassBuilderOptions, LLVMPassBuilderOptionsRef)
-LLVM_TYPEMAP(LLVMOpaquePassManagerBuilder, LLVMPassManagerBuilderRef)
-LLVM_TYPEMAP(LLVMOpaqueSectionIterator, LLVMSectionIteratorRef)
-LLVM_TYPEMAP(LLVMOpaqueSymbolIterator, LLVMSymbolIteratorRef)
-LLVM_TYPEMAP(LLVMOpaqueRelocationIterator, LLVMRelocationIteratorRef)
-LLVM_TYPEMAP(LLVMOpaqueMemoryBuffer, LLVMMemoryBufferRef)
-LLVM_TYPEMAP(LLVMOpaqueObjectFile, LLVMObjectFileRef)
-LLVM_TYPEMAP(LLVMOpaqueError, LLVMErrorRef)
-//%insert(go_wrapper) %{
-//func (l LLVMErrorRef) Error() string {
-//    return GetErrorMessage(l)
-//}
-//%}
+LLVM_TYPEMAP(LLVMContextRef)
+LLVM_TYPEMAP(LLVMModuleRef)
+LLVM_TYPEMAP(LLVMTypeRef)
+LLVM_TYPEMAP(LLVMValueRef)
+LLVM_TYPEMAP(LLVMBasicBlockRef)
+LLVM_TYPEMAP(LLVMMetadataRef)
+LLVM_TYPEMAP(LLVMNamedMDNodeRef)
+LLVM_TYPEMAP(LLVMValueMetadataEntry)
+LLVM_TYPEMAP(LLVMBuilderRef)
+LLVM_TYPEMAP(LLVMDIBuilderRef)
+LLVM_TYPEMAP(LLVMModuleProviderRef)
+LLVM_TYPEMAP(LLVMPassManagerRef)
+LLVM_TYPEMAP(LLVMPassRegistryRef)
+LLVM_TYPEMAP(LLVMUseRef)
+LLVM_TYPEMAP(LLVMAttributeRef)
+LLVM_TYPEMAP(LLVMDiagnosticInfoRef)
+LLVM_TYPEMAP(LLVMComdatRef)
+LLVM_TYPEMAP(LLVMModuleFlagEntry)
+LLVM_TYPEMAP(LLVMJITEventListenerRef)
+LLVM_TYPEMAP(LLVMBinaryRef)
+LLVM_TYPEMAP(LLVMTargetMachineRef)
+LLVM_TYPEMAP(LLVMTargetRef)
+LLVM_TYPEMAP(LLVMTargetDataRef)
+LLVM_TYPEMAP(LLVMTargetLibraryInfoRef)
+LLVM_TYPEMAP(LLVMPassBuilderOptionsRef)
+LLVM_TYPEMAP(LLVMPassManagerBuilderRef)
+LLVM_TYPEMAP(LLVMSectionIteratorRef)
+LLVM_TYPEMAP(LLVMSymbolIteratorRef)
+LLVM_TYPEMAP(LLVMRelocationIteratorRef)
+LLVM_TYPEMAP(LLVMMemoryBufferRef)
+LLVM_TYPEMAP(LLVMObjectFileRef)
+LLVM_TYPEMAP(LLVMErrorRef)
+
+%define LLVM_ENUM(NAME)
+%ignore NAME;
+%enddef
+
+LLVM_ENUM(LLVMOpcode)
+LLVM_ENUM(LLVMTypeKind)
+LLVM_ENUM(LLVMLinkage)
+LLVM_ENUM(LLVMVisibility)
+LLVM_ENUM(LLVMUnnamedAddr)
+LLVM_ENUM(LLVMDLLStorageClass)
+LLVM_ENUM(LLVMCallConv)
+LLVM_ENUM(LLVMValueKind)
+LLVM_ENUM(LLVMIntPredicate)
+LLVM_ENUM(LLVMRealPredicate)
+LLVM_ENUM(LLVMCallConv)
+LLVM_ENUM(LLVMLandingPadClauseTy)
+LLVM_ENUM(LLVMThreadLocalMode)
+LLVM_ENUM(LLVMAtomicOrdering)
+LLVM_ENUM(LLVMAtomicRMWBinOp)
+LLVM_ENUM(LLVMDiagnosticSeverity)
+LLVM_ENUM(LLVMInlineAsmDialect)
+LLVM_ENUM(LLVMModuleFlagBehavior)
 
 // Handle some APIs manually
 %ignore LLVMGetTargetFromTriple;

--- a/llvm/wrappers.go
+++ b/llvm/wrappers.go
@@ -1,0 +1,120 @@
+// This file contains wrappers that are too difficult for SWIG to handle auto-magically
+
+package llvm
+
+/*
+#include <stdlib.h>
+#include "llvm-c/Analysis.h"
+#include "llvm-c/Core.h"
+#include "llvm-c/Types.h"
+#include "llvm-c/Target.h"
+#include "llvm-c/TargetMachine.h"
+*/
+import "C"
+import "unsafe"
+
+// GetTargetFromTriple Finds the target corresponding to the given triple and stores it in T.
+func GetTargetFromTriple(triple string) (target LLVMTargetRef, errStr string, ok bool) {
+	CTriple := C.CString(triple)
+	defer C.free(unsafe.Pointer(CTriple))
+
+	var CTarget C.LLVMTargetRef
+	var CErrStr *C.char
+
+	result := C.LLVMGetTargetFromTriple(CTriple, &CTarget, &CErrStr)
+	ok = result == 0
+	if CErrStr != nil {
+		errStr = C.GoString(CErrStr)
+		C.LLVMDisposeMessage(CErrStr)
+	}
+
+	target = LLVMTargetRef(unsafe.Pointer(CTarget))
+	return
+}
+
+// AddIncoming adds an incoming value to the end of a PHI list.
+func AddIncoming(phi LLVMValueRef, edges []LLVMValueRef, blocks []LLVMBasicBlockRef) {
+	if len(edges) != len(blocks) {
+		panic("there must be as many edges as blocks")
+	}
+
+	edgesArr := (*C.LLVMValueRef)(C.malloc(C.size_t(len(edges)) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+	blocksArr := (*C.LLVMBasicBlockRef)(C.malloc(C.size_t(len(edges)) * C.size_t(unsafe.Sizeof(uintptr(0)))))
+	defer C.free(unsafe.Pointer(edgesArr))
+	defer C.free(unsafe.Pointer(blocksArr))
+
+	for i, edge := range edges {
+		*(*C.LLVMValueRef)(unsafe.Pointer(uintptr(unsafe.Pointer(edgesArr)) + uintptr(i)*unsafe.Sizeof(uintptr(0)))) = (C.LLVMValueRef)(unsafe.Pointer(edge))
+		*(*C.LLVMBasicBlockRef)(unsafe.Pointer(uintptr(unsafe.Pointer(blocksArr)) + uintptr(i)*unsafe.Sizeof(uintptr(0)))) = (C.LLVMBasicBlockRef)(unsafe.Pointer(blocks[i]))
+	}
+
+	C.LLVMAddIncoming(C.LLVMValueRef(unsafe.Pointer(phi)), edgesArr, blocksArr, C.uint(len(edges)))
+}
+
+func GetParamTypes(FunctionTy LLVMTypeRef) (result []LLVMTypeRef) {
+	count := int(CountParamTypes(FunctionTy))
+	output := make([]C.LLVMTypeRef, count)
+	if count > 0 {
+		C.LLVMGetParamTypes(C.LLVMTypeRef(unsafe.Pointer(FunctionTy)), (*C.LLVMTypeRef)(unsafe.Pointer(&output[0])))
+	}
+	result = make([]LLVMTypeRef, 0, count)
+	for _, value := range output {
+		result = append(result, LLVMTypeRef(unsafe.Pointer(value)))
+	}
+	return
+}
+
+func GetStructElementTypes(StructTy LLVMTypeRef) (result []LLVMTypeRef) {
+	count := int(CountStructElementTypes(StructTy))
+	output := make([]C.LLVMTypeRef, count)
+	if count > 0 {
+		C.LLVMGetStructElementTypes(C.LLVMTypeRef(unsafe.Pointer(StructTy)), (*C.LLVMTypeRef)(unsafe.Pointer(&output[0])))
+	}
+	result = make([]LLVMTypeRef, 0, count)
+	for _, value := range output {
+		result = append(result, LLVMTypeRef(unsafe.Pointer(value)))
+	}
+	return
+}
+
+func TypeIsEqual(a, b LLVMTypeRef) bool {
+	return a == b
+}
+
+func TargetMachineEmitToFile2(machine LLVMTargetMachineRef, module LLVMModuleRef, output string, fileType LLVMCodeGenFileType) (ok bool, errMsg string) {
+	COutput := C.CString(output)
+	defer C.free(unsafe.Pointer(COutput))
+
+	var CErrStr *C.char
+
+	result := C.LLVMTargetMachineEmitToFile(
+		C.LLVMTargetMachineRef(unsafe.Pointer(machine)),
+		C.LLVMModuleRef(unsafe.Pointer(module)),
+		COutput,
+		C.LLVMCodeGenFileType(fileType),
+		&CErrStr)
+
+	ok = result == 0
+	if CErrStr != nil {
+		errMsg = C.GoString(CErrStr)
+		C.LLVMDisposeMessage(CErrStr)
+	}
+	return
+}
+
+func VerifyModule2(module LLVMModuleRef, failureAction LLVMVerifierFailureAction) (ok bool, errMsg string) {
+	var CErrStr *C.char
+	result := C.LLVMVerifyModule(C.LLVMModuleRef(unsafe.Pointer(module)), C.LLVMVerifierFailureAction(failureAction), &CErrStr)
+	ok = result == 0
+	if CErrStr != nil {
+		errMsg = C.GoString(CErrStr)
+		C.LLVMDisposeMessage(CErrStr)
+	}
+	return
+}
+
+func GetValueName2(value LLVMValueRef) string {
+	var length C.size_t
+	nameStr := C.LLVMGetValueName2(C.LLVMValueRef(unsafe.Pointer(value)), (*C.size_t)(&length))
+	return C.GoStringN(nameStr, C.int(length))
+}

--- a/src/peripheral/spi.go
+++ b/src/peripheral/spi.go
@@ -1,0 +1,10 @@
+package peripheral
+
+import "io"
+
+type SPI interface {
+	io.ReadWriter
+	Transact(b []byte) []byte
+	Select()
+	Deselect()
+}

--- a/src/runtime/arm/cortexm/sam/atsamx51/internal/ringbuffer.go
+++ b/src/runtime/arm/cortexm/sam/atsamx51/internal/ringbuffer.go
@@ -1,8 +1,8 @@
-package uart
+package internal
 
 import "errors"
 
-type ringBuffer struct {
+type RingBuffer struct {
 	buffer []byte
 	begin  uint8
 	end    uint8
@@ -18,13 +18,13 @@ const (
 	defaultBufferSz = 256
 )
 
-func newBuffer(sz uintptr) ringBuffer {
+func NewRingBuffer(sz uintptr) RingBuffer {
 	if sz == 0 {
 		sz = defaultBufferSz
 	}
 
 	arr := make([]byte, sz)
-	buf := ringBuffer{
+	buf := RingBuffer{
 		buffer: arr,
 		begin:  0,
 		end:    0,
@@ -36,7 +36,7 @@ func newBuffer(sz uintptr) ringBuffer {
 	return buf
 }
 
-func (r *ringBuffer) Read(p []byte) (n int, err error) {
+func (r *RingBuffer) Read(p []byte) (n int, err error) {
 	if r.end > r.begin {
 		// Copy between start and end
 		n = copy(p, r.buffer[r.begin:r.end])
@@ -57,7 +57,7 @@ func (r *ringBuffer) Read(p []byte) (n int, err error) {
 	return
 }
 
-func (r *ringBuffer) Write(p []byte) (n int, err error) {
+func (r *RingBuffer) Write(p []byte) (n int, err error) {
 	for n < len(p) {
 		if r.end > r.begin {
 			n += copy(r.buffer[r.end:], p)
@@ -77,7 +77,7 @@ func (r *ringBuffer) Write(p []byte) (n int, err error) {
 	return
 }
 
-func (r *ringBuffer) WriteString(str string) (n int, err error) {
+func (r *RingBuffer) WriteString(str string) (n int, err error) {
 	for _, b := range str {
 		if err = r.WriteByte(byte(b)); err != nil {
 			return n, err
@@ -87,7 +87,7 @@ func (r *ringBuffer) WriteString(str string) (n int, err error) {
 	return
 }
 
-func (r *ringBuffer) ReadByte() (byte, error) {
+func (r *RingBuffer) ReadByte() (byte, error) {
 	if !r.full && r.end == r.begin {
 		return 0, errBufferIsEmpty
 	}
@@ -105,7 +105,7 @@ func (r *ringBuffer) ReadByte() (byte, error) {
 	return b, nil
 }
 
-func (r *ringBuffer) WriteByte(b byte) error {
+func (r *RingBuffer) WriteByte(b byte) error {
 	if r.full {
 		return errBufferIsFull
 	}
@@ -125,7 +125,7 @@ func (r *ringBuffer) WriteByte(b byte) error {
 	return nil
 }
 
-func (r *ringBuffer) Len() int {
+func (r *RingBuffer) Len() int {
 	if r.full {
 		return len(r.buffer)
 	} else if r.end > r.begin {

--- a/src/runtime/arm/cortexm/sam/atsamx51/pin.go
+++ b/src/runtime/arm/cortexm/sam/atsamx51/pin.go
@@ -182,6 +182,25 @@ const (
 	PD31 Pin = 0x0000_031F | NoPAD | NoALT
 )
 
+type PMUXFunction uint8
+
+const (
+	PMUXFunctionA PMUXFunction = iota
+	PMUXFunctionB
+	PMUXFunctionC
+	PMUXFunctionD
+	PMUXFunctionE
+	PMUXFunctionF
+	PMUXFunctionG
+	PMUXFunctionH
+	PMUXFunctionI
+	PMUXFunctionJ
+	PMUXFunctionK
+	PMUXFunctionL
+	PMUXFunctionM
+	PMUXFunctionN
+)
+
 var (
 	handlerFuncs [16]func(Pin)
 	handlerPins  [16]Pin
@@ -272,15 +291,15 @@ func (p Pin) SetInterrupt(mode int, handler func(Pin)) {
 	irq.EnableIRQ()
 }
 
-func (p Pin) SetPMUX(mode uint8, enabled bool) {
+func (p Pin) SetPMUX(mode PMUXFunction, enabled bool) {
 	// Set up PMUX
 	portgroup := &chip.PORT.GROUP[0xFF&(p>>8)]
 	pmux := int(p&0xFF) / 2
 	if (p&0xFF)%2 == 0 {
 		// Pin is odd numbered
-		portgroup.PMUX[pmux].SetPMUXE(mode)
+		portgroup.PMUX[pmux].SetPMUXE(uint8(mode))
 	} else {
-		portgroup.PMUX[pmux].SetPMUXO(mode)
+		portgroup.PMUX[pmux].SetPMUXO(uint8(mode))
 	}
 	portgroup.PINCFG[p&0xFF].SetPMUXEN(enabled)
 }

--- a/src/runtime/arm/cortexm/sam/atsamx51/spi/spi.go
+++ b/src/runtime/arm/cortexm/sam/atsamx51/spi/spi.go
@@ -1,0 +1,245 @@
+package spi
+
+import (
+	"runtime/arm/cortexm/sam/atsamx51"
+	"runtime/arm/cortexm/sam/atsamx51/internal"
+	"runtime/arm/cortexm/sam/chip"
+	"sync"
+)
+
+var (
+	SPI0 = &SPI{SERCOM: 0}
+	SPI1 = &SPI{SERCOM: 1}
+	SPI2 = &SPI{SERCOM: 2}
+	SPI3 = &SPI{SERCOM: 3}
+	SPI4 = &SPI{SERCOM: 4}
+	SPI5 = &SPI{SERCOM: 5}
+	SPI6 = &SPI{SERCOM: 6}
+	SPI7 = &SPI{SERCOM: 7}
+	spi  = [8]*SPI{
+		SPI0,
+		SPI1,
+		SPI2,
+		SPI3,
+		SPI4,
+		SPI5,
+		SPI6,
+		SPI7,
+	}
+)
+
+const (
+	HostMode   = chip.SERCOMSPIMCTRLAMODESelectSPI_MASTER
+	ClientMode = chip.SERCOMSPIMCTRLAMODESelectSPI_SLAVE
+
+	MSB = chip.SERCOMSPIMCTRLADORDSelectMSB
+	LSB = chip.SERCOMSPIMCTRLADORDSelectLSB
+
+	Frame            = chip.SERCOMSPIMCTRLAFORMSelectSPI_FRAME
+	FrameWithAddress = chip.SERCOMSPIMCTRLAFORMSelectSPI_FRAME_WITH_ADDR
+
+	LeadingEdge  = chip.SERCOMSPIMCTRLACPHASelectLEADING_EDGE
+	TrailingEdge = chip.SERCOMSPIMCTRLACPHASelectTRAILING_EDGE
+
+	IdleLow  = chip.SERCOMSPIMCTRLACPOLSelectIDLE_LOW
+	IdleHigh = chip.SERCOMSPIMCTRLACPOLSelectIDLE_HIGH
+)
+
+const (
+	errStrInvalidPin = "(SPI): invalid pin configuration"
+)
+
+type SPI struct {
+	atsamx51.SERCOM
+	config   Config
+	txBuffer internal.RingBuffer
+	rxBuffer internal.RingBuffer
+	mutex    sync.Mutex
+}
+
+type Config struct {
+	DI  atsamx51.Pin
+	DO  atsamx51.Pin
+	SCK atsamx51.Pin
+	CS  atsamx51.Pin
+
+	BaudHz         uint
+	CharacterSize  uint8
+	DataOrder      chip.SERCOMSPIMCTRLADORDSelect
+	Form           chip.SERCOMSPIMCTRLAFORMSelect
+	HardwareSelect bool
+	Mode           chip.SERCOMSPIMCTRLAMODESelect
+	Phase          chip.SERCOMSPIMCTRLACPHASelect
+	Polarity       chip.SERCOMSPIMCTRLACPOLSelect
+	ReceiveEnabled bool
+
+	RXBufferSize uintptr
+	TXBufferSize uintptr
+}
+
+func (s *SPI) Configure(config Config) {
+	var mode atsamx51.PMUXFunction
+	var doPad int
+	var diPad int
+
+	// Validate pinout
+	if config.DO.GetPAD() == 0 || config.DO.GetPAD() == 3 {
+		mode = atsamx51.PMUXFunctionC
+		doPad = config.DO.GetPAD()
+		diPad = config.DI.GetPAD()
+		if diPad == config.DO.GetPAD() ||
+			diPad == config.SCK.GetPAD() ||
+			(config.HardwareSelect && diPad == config.CS.GetPAD()) ||
+			config.SCK.GetPAD() != 1 ||
+			(config.HardwareSelect && config.CS.GetPAD() != 2) ||
+			config.DO == atsamx51.NoPin ||
+			config.DI == atsamx51.NoPin ||
+			config.SCK == atsamx51.NoPin ||
+			(config.HardwareSelect && config.CS == atsamx51.NoPin) {
+			panic(errStrInvalidPin)
+		}
+	} else if config.DO.GetAltPAD() == 0 || config.DO.GetAltPAD() == 3 {
+		mode = atsamx51.PMUXFunctionD
+		doPad = config.DO.GetAltPAD()
+		diPad = config.DI.GetAltPAD()
+		if diPad == config.DO.GetAltPAD() ||
+			diPad == config.SCK.GetAltPAD() ||
+			(config.HardwareSelect && diPad == config.CS.GetAltPAD()) ||
+			config.SCK.GetAltPAD() != 1 ||
+			(config.HardwareSelect && config.CS.GetAltPAD() != 2) ||
+			config.DO == atsamx51.NoPin ||
+			config.DI == atsamx51.NoPin ||
+			config.SCK == atsamx51.NoPin ||
+			(config.HardwareSelect && config.CS == atsamx51.NoPin) {
+			panic(errStrInvalidPin)
+		}
+	} else {
+		panic(errStrInvalidPin)
+	}
+
+	// DO can be on either PAD0 (0x0) or PAD3 (0x2)
+	if doPad == 3 {
+		// Set to the alternate pinout
+		doPad = 2
+	}
+
+	// Set the pin configurations
+	config.DI.SetPMUX(mode, true)
+	config.DO.SetPMUX(mode, true)
+	config.SCK.SetPMUX(mode, true)
+	if config.HardwareSelect {
+		config.CS.SetPMUX(mode, true)
+	} else {
+		// Set the CS pin to output mode
+		config.CS.SetDirection(1)
+	}
+
+	// Enable the SERCOM
+	s.SetEnabled(true)
+
+	// Calculate the BAUD value
+	baud := s.Baud(config.BaudHz)
+
+	// Set up the registers
+	chip.SERCOM[s.SERCOM].SPIM.BAUD.SetBAUD(baud)
+
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetDORD(config.DataOrder)
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetFORM(config.Form)
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetMODE(config.Mode)
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetCPHA(config.Phase)
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetCPOL(config.Polarity)
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetDIPO(chip.SERCOMSPIMCTRLADIPOSelect(diPad))
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetDOPO(chip.SERCOMSPIMCTRLADOPOSelect(doPad))
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetCPOL(config.Polarity)
+
+	chip.SERCOM[s.SERCOM].SPIM.CTRLB.SetRXEN(config.ReceiveEnabled)
+	chip.SERCOM[s.SERCOM].SPIM.CTRLB.SetMSSEN(config.HardwareSelect)
+	switch config.CharacterSize {
+	case 9:
+		chip.SERCOM[s.SERCOM].SPIM.CTRLB.SetCHSIZE(chip.SERCOMSPIMCTRLBCHSIZESelect9_BIT)
+	default:
+		chip.SERCOM[s.SERCOM].SPIM.CTRLB.SetCHSIZE(chip.SERCOMSPIMCTRLBCHSIZESelect8_BIT)
+	}
+
+	// Set up buffers
+	rx := internal.NewRingBuffer(config.RXBufferSize)
+	tx := internal.NewRingBuffer(config.TXBufferSize)
+
+	s.rxBuffer = rx
+	s.txBuffer = tx
+
+	// Set the interrupt handler
+	atsamx51.SERCOMHandlers[s.SERCOM][0].Set(irqHandler)
+
+	// Enable interrupts
+	s.Irq0().EnableIRQ()
+	chip.SERCOM[s.SERCOM].SPIM.INTENSET.SetRXC(true)
+
+	// Enable the peripheral
+	chip.SERCOM[s.SERCOM].SPIM.CTRLA.SetENABLE(true)
+	for chip.SERCOM[s.SERCOM].SPIM.SYNCBUSY.GetENABLE() {
+	}
+
+	s.config = config
+}
+
+func (s *SPI) Read(p []byte) (n int, err error) {
+	return s.rxBuffer.Read(p)
+}
+
+func (s *SPI) Write(p []byte) (n int, err error) {
+	s.mutex.Lock()
+	// Write the string to the TX buffer
+	n, err = s.txBuffer.Write(p)
+
+	// Enable the DRE interrupt that will write the bytes from the buffer
+	chip.SERCOM[s.SERCOM].SPIM.INTENSET.SetDRE(true)
+	s.mutex.Unlock()
+	return
+}
+
+func (s *SPI) Transact(b []byte) []byte {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *SPI) Select() {
+	if !s.config.HardwareSelect {
+		s.config.CS.Set(false)
+	}
+}
+
+func (s *SPI) Deselect() {
+	if !s.config.HardwareSelect {
+		s.config.CS.Set(true)
+	}
+}
+
+func irqHandler() {
+	sercom := int(chip.SystemControl.ICSR.GetVECTACTIVE()-62) / 4
+	switch {
+	case chip.SERCOM[sercom].SPIM.INTFLAG.GetRXC():
+		rxcHandler(sercom)
+	case chip.SERCOM[sercom].SPIM.INTFLAG.GetDRE():
+		dreHandler(sercom)
+	}
+}
+
+func rxcHandler(sercom int) {
+	b := byte(chip.SERCOM[sercom].SPIM.DATA.GetDATA())
+	spi[sercom].rxBuffer.WriteByte(b)
+}
+
+func dreHandler(sercom int) {
+	for spi[sercom].txBuffer.Len() > 0 {
+		if b, err := spi[sercom].txBuffer.ReadByte(); err == nil {
+			for !chip.SERCOM[sercom].SPIM.INTFLAG.GetDRE() {
+			}
+			chip.SERCOM[sercom].SPIM.DATA.SetDATA(uint32(b))
+		} else {
+			// Stop if there was an error reading the next byte
+			break
+		}
+	}
+	chip.SERCOM[sercom].USART_INT.INTENCLR.SetDRE(true)
+}

--- a/src/runtime/arm/cortexm/sam/atsamx51/uart/uart.go
+++ b/src/runtime/arm/cortexm/sam/atsamx51/uart/uart.go
@@ -2,6 +2,7 @@ package uart
 
 import (
 	"runtime/arm/cortexm/sam/atsamx51"
+	"runtime/arm/cortexm/sam/atsamx51/internal"
 	"runtime/arm/cortexm/sam/chip"
 	"sync"
 )
@@ -34,8 +35,8 @@ var (
 
 type UART struct {
 	sercom   int
-	txBuffer ringBuffer
-	rxBuffer ringBuffer
+	txBuffer internal.RingBuffer
+	rxBuffer internal.RingBuffer
 	mutex    sync.Mutex
 }
 
@@ -56,12 +57,12 @@ type Config struct {
 }
 
 func (u *UART) Configure(config Config) {
-	var mode uint8
+	var mode atsamx51.PMUXFunction
 	var rxPad int
 
 	// Determine the SERCOM number from the PAD value of TXD pin
 	if config.TXD.GetPAD() == 0 {
-		mode = 0x2
+		mode = atsamx51.PMUXFunctionC
 		rxPad = config.RXD.GetPAD()
 		// Check the other optional pins
 		if config.TXD.GetSERCOM() != u.sercom ||
@@ -76,7 +77,7 @@ func (u *UART) Configure(config Config) {
 			panic("invalid selection")
 		}
 	} else if config.TXD.GetAltPAD() == 0 {
-		mode = 0x3
+		mode = atsamx51.PMUXFunctionD
 		rxPad = config.RXD.GetAltPAD()
 		// Check the other optional pins
 		if config.TXD.GetAltSERCOM() != u.sercom ||
@@ -198,8 +199,8 @@ func (u *UART) Configure(config Config) {
 		}
 	}
 
-	rx := newBuffer(config.RXBufferSize)
-	tx := newBuffer(config.TXBufferSize)
+	rx := internal.NewRingBuffer(config.RXBufferSize)
+	tx := internal.NewRingBuffer(config.TXBufferSize)
 
 	u.rxBuffer = rx
 	u.txBuffer = tx


### PR DESCRIPTION
Builder:
Builder will now round-trip modules to and from bitcode in order to linker each module into a single module to perform optimizations on. Added optimizer setting.

Compiler:
Handle untyped strings and booleans.
Corrected scope start line information for functions. Corrected debug information about functions that exist in external packages.

Runtime:
Implemented SPI for ATSAMx51 series chips.
Created SERCOM wrapper type for ATSAMx51.

Other:
Replaced missing LLVM wrapper implementations written by hand. Refactored LLVM's enums; added all enums.