### PR TITLE
Initial implementation for the defer keyword, recover builtin and typ…

### DIFF
--- a/compiler/builtin.go
+++ b/compiler/builtin.go
@@ -121,7 +121,7 @@ func (c *Compiler) createBuiltinCall(ctx context.Context, builtin *ssa.Builtin, 
 	case "real":
 		panic("not implemented")
 	case "recover":
-		panic("not implemented")
+		value = c.createRuntimeCall(ctx, "_recover", nil)
 	case "Add":
 		// Add to pointer values
 		value = llvm.BuildGEP2(c.builder, llvm.Int8TypeInContext(c.currentContext(ctx)), argValues[0].UnderlyingValue(ctx), []llvm.LLVMValueRef{argValues[1].UnderlyingValue(ctx)}, "")

--- a/compiler/testdata/schedulertest/main.go
+++ b/compiler/testdata/schedulertest/main.go
@@ -22,6 +22,15 @@ var (
 )
 
 func initMCU() {
+	defer func() {
+		if err := recover(); err != nil {
+			UART.WriteString(err.(string) + "\n")
+			UART.WriteString("Recovered!\n")
+		}
+	}()
+	defer UART.WriteString("MCU initialized 2\n")
+	defer UART.WriteString("MCU initialized 1\n")
+
 	mcu.DefaultClocks()
 	UART.Configure(uart.Config{
 		TXD:             mcu.PB02,
@@ -49,6 +58,8 @@ func initMCU() {
 		Polarity:       spi.IdleLow,
 		ReceiveEnabled: true,
 	})
+
+	panic("testing defers upon panic")
 }
 
 func main() {
@@ -83,6 +94,6 @@ func main() {
 	}(mutex)
 
 	for {
-		UART.WriteString("test\n")
+		//UART.WriteString("test\n")
 	}
 }

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -127,3 +127,19 @@ func (c *Compiler) createType(ctx context.Context, typ types.Type) *Type {
 	// Return the type
 	return result
 }
+
+func (c *Compiler) createRuntimeType(ctx context.Context, typename string) *Type {
+	// Get the runtime package
+	runtimePkg := c.currentPackage(ctx).Prog.ImportedPackage("runtime")
+	if runtimePkg == nil {
+		panic("no runtime package")
+	}
+
+	// Get the type within the runtime package
+	t := runtimePkg.Type(typename)
+	if t == nil {
+		panic(typename + " does not exist in runtime")
+	}
+
+	return c.createType(ctx, t.Type())
+}

--- a/src/runtime/arm/cortexm/tasks.S
+++ b/src/runtime/arm/cortexm/tasks.S
@@ -21,11 +21,13 @@ PendSV_Handler:
     // Load the stack pointer of the current task
     ldr r0, =runtime._currentTask   // Load the address of the current task pointer into R0
     ldr r0, [r0]                    // Load the current task into R0
-    ldr r0, [r0]                    // Load the stack pointer into R0
-
     ldr r1, =runtime._lastTask      // Load the last task pointer into R1
     ldr r1, [r1]                    // Load the value of the last task pointer into R1
-    cmp r1, #0                      // Check if the value of the poitner to the last task is 0
+    cmp r1, r0                      // Compare the last task to the current task
+    beq _return                     // Do nothing if the task has not changed
+
+    ldr r0, [r0]                    // Load the stack pointer into R0
+    cmp r1, #0                      // Check if the value of the pointer to the last task is 0
     beq _context_switch             // Skip saving the context of the last task if there was no last task
 
     // Save context of old task
@@ -63,6 +65,7 @@ _context_switch:
     ldr lr, [r0]                    // Load lr from the new task's stack
 #endif
     msr psp, r0;                    // Update PSP
+_return:
     ldr lr, =0xFFFFFFFD             // Set EXC_RETURN value for return to Thread mode with PSP
     bx lr                           // Use EXC_RETURN to set the next PC
 .size PendSV_Handler, .-PendSV_Handler

--- a/src/runtime/defer.go
+++ b/src/runtime/defer.go
@@ -4,9 +4,61 @@ import (
 	"unsafe"
 )
 
-type deferEntry struct {
-	fn      unsafe.Pointer
-	args    unsafe.Pointer
-	numArgs int
-	next    *unsafe.Pointer
+type deferFrame struct {
+	fn   unsafe.Pointer
+	ctx  unsafe.Pointer
+	next *deferFrame
+	top  *deferFrame
 }
+
+func deferPush(fn unsafe.Pointer, ctx unsafe.Pointer, top **deferFrame) {
+	state := disableInterrupts()
+	if *top == nil {
+		// Initialize the top pointer for the duration of the callee
+		*top = deferCurrentTop()
+	}
+
+	currentTask.deferStack = &deferFrame{
+		fn:   fn,
+		ctx:  ctx,
+		next: currentTask.deferStack,
+		top:  *top,
+	}
+	enableInterrupts(state)
+}
+
+func deferRun(top *deferFrame) {
+	lastState := currentTask.state
+	for currentTask.deferStack != top && currentTask.deferStack != nil {
+		frame := currentTask.deferStack
+
+		// Pop frame from stack
+		currentTask.deferStack = frame.next
+
+		// Call the deferred function
+		deferCall(frame.fn, frame.ctx)
+
+		// Check if a panic recovered
+		if lastState == taskPanicking && currentTask.state == taskRecovered {
+			// Transition this task back to the running state
+			currentTask.state = taskRunning
+
+			// Stop the panic sequence
+			break
+		}
+	}
+}
+
+func deferCurrentTop() *deferFrame {
+	return currentTask.deferStack
+}
+
+func deferInitialTop() *deferFrame {
+	if currentTask.deferStack != nil {
+		return currentTask.deferStack.top
+	}
+	return nil
+}
+
+// deferCall is an intrinsic for executing the deferred function
+func deferCall(fn unsafe.Pointer, ctx unsafe.Pointer)

--- a/src/runtime/error.go
+++ b/src/runtime/error.go
@@ -1,0 +1,42 @@
+package runtime
+
+type Error interface {
+	error
+	RuntimeError()
+}
+
+type TypeAssertError struct {
+	_interface    *typeDescriptor
+	concrete      *typeDescriptor
+	asserted      *typeDescriptor
+	missingMethod string
+}
+
+func (*TypeAssertError) RuntimeError() {}
+
+func (e *TypeAssertError) Error() string {
+	inter := "interface"
+	if e._interface != nil {
+		inter = *e._interface.name
+	}
+	as := *e.asserted.name
+	if e.concrete == nil {
+		return "interface conversion: " + inter + " is nil, not " + as
+	}
+	cs := *e.concrete.name
+	if len(e.missingMethod) == 0 {
+		msg := "interface conversion: " + inter + " is " + cs + ", not " + as
+		// TODO: Need to store package path in type information
+		/*if cs == as {
+			e.concrete.pkgpath() != e.asserted.pkgpath() {
+				msg += " (types from different packages)"
+			} else {
+				msg += " (types from different scopes)"
+			}
+		}*/
+		return msg
+	}
+
+	return "interface conversion: " + cs + " is not " +
+		as + ": missing method " + e.missingMethod
+}

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -1,10 +1,30 @@
 package runtime
 
-//go:export panicHandler runtime._panic
 func _panic(arg any) {
+	// Transition the current task to the panicking state
+	currentTask.state = taskPanicking
+
+	// Store the arg in the current goroutine's context
+	currentTask.panicValue = arg
+
 	// TODO: Attempt to print the arguments
-	// TODO: Call the current function's defer stack
+
+	// Call the current goroutine's defer stack
+	deferRun(nil)
 
 	// Abort if not recovered
-	abort()
+	if currentTask.state == taskPanicking {
+		abort()
+	}
+}
+
+func _recover() any {
+	if currentTask.state == taskPanicking {
+		// Transition task state to recovered
+		currentTask.state = taskRecovered
+
+		// Return the argument passed to panic
+		return currentTask.panicValue
+	}
+	return nil
 }

--- a/src/runtime/type.go
+++ b/src/runtime/type.go
@@ -6,7 +6,7 @@ import "unsafe"
 type BasicKind int
 
 const (
-	Invalid BasicKind = iota // type is invalid
+	InvalidBasicKind BasicKind = iota // type is invalid
 
 	// predeclared types
 	Bool
@@ -42,17 +42,32 @@ const (
 	Rune = Int32
 )
 
+type ConstructType int
+
+const (
+	InvalidConstructType ConstructType = iota
+	Primitive
+	Pointer
+	Interface
+	Struct
+	Array
+	Slice
+	Map
+	Channel
+)
+
 type typeDescriptor struct {
-	name     *string
-	size     uintptr
-	kind     BasicKind
-	methods  *methodTable
-	fields   *fieldTable
-	array    *arrayDescriptor
-	mapp     *mapTypeDescriptor
-	ptr      *pointerDescriptor
-	channel  *channelTypeDescriptor
-	function *functionDescriptor
+	name      *string
+	size      uintptr
+	construct ConstructType
+	kind      BasicKind
+	methods   *methodTable
+	fields    *fieldTable
+	array     *arrayDescriptor
+	mapp      *mapTypeDescriptor
+	ptr       *pointerDescriptor
+	channel   *channelTypeDescriptor
+	function  *functionDescriptor
 }
 
 type methodTable struct {


### PR DESCRIPTION
…e asserts.

Builder:
None

Compiler:
Implemented defer instruction.
Fixed bug in createFunction where the function declaration can be duplicated when the function is not in the current package. Implemented recover builtin.
Implemented interface type assert instructions.

Runtime:
Implemented defer runtime.
Implemented recover for panics.
Implemented interface type assert runtime.
Added "construct" field to type information so that the runtime can tell the difference between interfaces, structs, array, slices, etc...

Other: