### PR TITLE
Removed more direct runtime call in IR generation.

### DIFF
--- a/compiler/ssa/compare.go
+++ b/compiler/ssa/compare.go
@@ -91,31 +91,12 @@ func (b *Builder) emitComplexCompare(ctx context.Context, op token.Token, X mlir
 	return resultOf(cmpOp)
 }
 
-func (b *Builder) emitInterfaceCompare(ctx context.Context, op token.Token, X mlir.Value, Y mlir.Value, YT types.Type, location mlir.Location) mlir.Value {
-	var result mlir.Value
-	if typeIs[*types.Interface](YT) {
-		// Emit the runtime call to compare the two interface types.
-		op := mlir.GoCreateRuntimeCallOperation(b.ctx, mangleSymbol("runtime.interfaceCompare"), b.types(b.i1), b.values(X, Y), location)
-		appendOperation(ctx, op)
-		result = resultOf(op)
-	} else {
-		typeInfoOp := mlir.GoCreateTypeInfoOperation(b.ctx, b.typeInfoPtr, b.GetType(ctx, YT), location)
-		appendOperation(ctx, typeInfoOp)
-		infoValue := resultOf(typeInfoOp)
+func (b *Builder) emitInterfaceCompare(ctx context.Context, predicate token.Token, X mlir.Value, Y mlir.Value, YT types.Type, location mlir.Location) mlir.Value {
+	op := mlir.GoCreateCmpInterfaceOperation(b.ctx, b.i1, X, Y, location)
+	appendOperation(ctx, op)
+	result := resultOf(op)
 
-		// Take the address of the RHS value.
-		Y = b.makeCopyOf(ctx, Y, location)
-
-		// Reinterpret the pointer as an unsafe.Pointer.
-		Y = b.bitcastTo(ctx, Y, b.ptr, location)
-
-		// Emit the runtime call to compare the interface type against the arbitrary value.
-		op := mlir.GoCreateRuntimeCallOperation(b.ctx, mangleSymbol("runtime.interfaceCompareTo"), b.types(b.i1), b.values(X, infoValue, Y), location)
-		appendOperation(ctx, op)
-		result = resultOf(op)
-	}
-
-	if op == token.NEQ {
+	if predicate == token.NEQ {
 		// Negate the result.
 		result = b.emitNegation(ctx, result, location)
 	}

--- a/compiler/ssa/emit.go
+++ b/compiler/ssa/emit.go
@@ -426,6 +426,7 @@ func (b *Builder) emitGenericDecl(ctx context.Context, decl *ast.GenDecl) {
 		for _, spec := range decl.Specs {
 			spec := spec.(*ast.ValueSpec)
 			vars := make([]Value, len(spec.Names))
+			location := b.location(decl.Pos())
 
 			// Local variables need to be emitted into the current block.
 			for i, ident := range spec.Names {
@@ -437,8 +438,26 @@ func (b *Builder) emitGenericDecl(ctx context.Context, decl *ast.GenDecl) {
 				// Evaluate the initial value.
 				result := b.emitExpr(ctx, expr)[0]
 
+				// Handle interface type conversion.
+				lhsType := b.typeOf(ctx, spec.Names[i])
+				rhsType := b.typeOf(ctx, expr)
+				if !isNil(rhsType) && !types.Identical(lhsType, rhsType) {
+					if types.IsInterface(baseType(rhsType)) {
+						// Convert from interface A to interface B.
+						result = b.emitChangeType(ctx, lhsType, result, location)
+					} else {
+						// Generate methods for named types.
+						if T, ok := rhsType.(*types.Named); ok {
+							b.queueNamedTypeJobs(ctx, T)
+						}
+
+						// Create an interface value from the value expression.
+						result = b.emitInterfaceValue(ctx, lhsType, rhsType, result, location)
+					}
+				}
+
 				// Store the initial value at the address of the variable.
-				vars[i].Store(ctx, result, b.location(decl.Pos()))
+				vars[i].Store(ctx, result, location)
 			}
 		}
 	default:

--- a/examples/arm/samx51/test/main.go
+++ b/examples/arm/samx51/test/main.go
@@ -39,37 +39,16 @@ func f() int {
 }
 
 func main() {
-	var a []int
-	var c, c1, c2, c3, c4 chan int
-	var i1, i2 int
-	select {
-	case i1 = <-c1:
-		use(i1)
-	case c2 <- i2:
-	case i3, ok := (<-c3): // same as: i3, ok := <-c3
-		if ok {
-			use(i3)
-		} else {
+	var iii0 any = 0
+	var iii1 any = 1
+	var iiii int = 3
 
-		}
-	case a[f()] = <-c4:
-		// same as:
-		// case t := <-c4
-		//	a[f()] = t
-	default:
-
-	}
-
-	for { // send random sequence of bits to c
-		select {
-		case c <- 0: // note: no statement, no fallthrough, no folding of cases
-		case c <- 1:
-		}
-	}
-
-	select {} // block forever
+	c0 := iii0 == iii1
+	c1 := iii0 == iiii
+	use(c0)
+	use(c1)
 }
 
-func use(v int) {
+func use(v bool) {
 
 }

--- a/goir/include/Go-c/mlir/Operations.h
+++ b/goir/include/Go-c/mlir/Operations.h
@@ -82,6 +82,13 @@ extern "C"
     MlirValue y,
     MlirLocation location);
 
+  MlirOperation mlirGoCreateCmpInterfaceOperation(
+    MlirContext context,
+    MlirType resultType,
+    MlirValue x,
+    MlirValue y,
+    MlirLocation location);
+
   MlirOperation mlirGoCreateDivCOperation(
     MlirContext context,
     MlirType resultType,

--- a/goir/include/Go/IR/Operations/BinOps.td
+++ b/goir/include/Go/IR/Operations/BinOps.td
@@ -12,7 +12,7 @@ include "mlir/IR/OpBase.td"
 
 class Go_BinOp<string mnemonic, list<Trait> traits = []> :
         Go_Op<mnemonic, traits # []> {
-    let assemblyFormat = "$lhs `,` $rhs attr-dict-with-keyword `:` type($result)";
+    let assemblyFormat = "$lhs `,` $rhs attr-dict-with-keyword `:` functional-type(operands, results)";
 }
 
 class Go_IntBinOp<string mnemonic, list<Trait> traits = []> :
@@ -216,6 +216,21 @@ def CmpIOp : Go_CompareOp<"cmpi", [NoMemoryEffect]> {
     let arguments = (ins Go_CmpIPredicate:$predicate,
                                Go_Integral:$lhs,
                                Go_Integral:$rhs);
+}
+
+//===----------------------------------------------------------------------===//
+// cmp.interface
+//===----------------------------------------------------------------------===//
+
+def CmpInterfaceOp : Go_BinOp<"cmp.interface", [NoMemoryEffect, Commutative]> {
+    let arguments = (ins
+        Go_Type:$lhs,
+        Go_Type:$rhs
+    );
+    let results = (outs
+        Go_Bool:$result
+    );
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/goir/lib/CAPI/mlir/Operations.cxx
+++ b/goir/lib/CAPI/mlir/Operations.cxx
@@ -138,6 +138,25 @@ MlirOperation mlirGoCreateCmpIOperation(
   return wrap(op);
 }
 
+MlirOperation mlirGoCreateCmpInterfaceOperation(
+    MlirContext context,
+    MlirType resultType,
+    MlirValue x,
+    MlirValue y,
+    MlirLocation location)
+{
+  auto _context = unwrap(context);
+  auto _x = unwrap(x);
+  auto _y = unwrap(y);
+  auto _resultType = unwrap(resultType);
+  auto _location = unwrap(location);
+
+  mlir::OpBuilder builder(_context);
+  mlir::Operation* op =
+    builder.create<::mlir::go::CmpInterfaceOp>(_location, _resultType, _x, _y);
+  return wrap(op);
+}
+
 MlirOperation mlirGoCreateDivCOperation(
   MlirContext context,
   MlirType resultType,

--- a/goir/lib/Go/IR/Operations/BinOps.cxx
+++ b/goir/lib/Go/IR/Operations/BinOps.cxx
@@ -1,86 +1,105 @@
 
+#include <mlir/Interfaces/Utils/InferIntRangeCommon.h>
+
 #include "Go/IR/GoDialect.h"
 #include "Go/IR/GoOps.h"
 
-#include <mlir/Interfaces/Utils/InferIntRangeCommon.h>
-
-namespace mlir::go {
-    void AddIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                          SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void AndOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void AndNotOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                  SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void DivUIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                    SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void DivSIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                    SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void MulIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void OrOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void RemSIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                  SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void RemUIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                  SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void ShlOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void ShrUIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void ShrSIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void SubIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    void XorOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
-                                   SetIntRangeFn setResultRange) {
-        setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
-    }
-
-    ::mlir::LogicalResult CmpCOp::verify() {
-        // Only == and != operators allowed for complex numbers as they are not ordered.
-        if (this->getPredicate() != CmpFPredicate::eq && this->getPredicate() != CmpFPredicate::ne)
-        {
-            return emitOpError() << "only `==` and `!=` operators allowed for complex numbers as they are not ordered";
-        }
-        return success();
-    }
+namespace mlir::go
+{
+void AddIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
 }
+
+void AndOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void AndNotOp::inferResultRanges(
+  ArrayRef<ConstantIntRanges> argRanges,
+  SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void DivUIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void DivSIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void MulIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void OrOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void RemSIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void RemUIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void ShlOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void ShrUIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void ShrSIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void SubIOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+void XorOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges, SetIntRangeFn setResultRange)
+{
+  setResultRange(getResult(), ::mlir::intrange::inferAdd(argRanges));
+}
+
+::mlir::LogicalResult CmpCOp::verify()
+{
+  // Only == and != operators allowed for complex numbers as they are not ordered.
+  if (this->getPredicate() != CmpFPredicate::eq && this->getPredicate() != CmpFPredicate::ne)
+  {
+    return emitOpError()
+      << "only `==` and `!=` operators allowed for complex numbers as they are not ordered";
+  }
+  return success();
+}
+
+mlir::LogicalResult CmpInterfaceOp::verify()
+{
+  // At least one parameter needs to be an interface type.
+  if (
+    !mlir::go::isa<InterfaceType>(this->getLhs().getType()) &&
+    !mlir::go::isa<InterfaceType>(this->getRhs().getType()))
+  {
+    return emitOpError() << "at least one operand MUST be an interface type";
+  }
+
+  return success();
+}
+
+} // namespace mlir::go

--- a/goir/lib/Go/Transforms/HeapEscapePass.cxx
+++ b/goir/lib/Go/Transforms/HeapEscapePass.cxx
@@ -108,7 +108,7 @@ struct HeapEscapePass : public PassWrapper<HeapEscapePass, OperationPass<mlir::g
               }
               return Result::DoesNotEscape;
             })
-          .Case([&](MakeInterfaceOp) { return Result::EscapesToHeap; })
+          .Case([&](MakeInterfaceOp makeOp) { return this->analyzeOperation(makeOp, visited); })
           .Case([&](ReturnOp) { return Result::EscapesToHeap; })
           .Case([&](SliceAddrOp sliceAddrOp)
                 { return this->analyzeOperation(sliceAddrOp.getSlice().getDefiningOp(), visited); })

--- a/goir/lib/Go/Transforms/LowerToLLVM.cxx
+++ b/goir/lib/Go/Transforms/LowerToLLVM.cxx
@@ -1254,6 +1254,85 @@ struct ConstantOpLowering : ConvertOpToLLVMPattern<ConstantOp>
   }
 };
 
+struct CmpInterfaceOpLowering : ConvertOpToLLVMPattern<CmpInterfaceOp>
+{
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult matchAndRewrite(
+    CmpInterfaceOp op,
+    OpAdaptor adaptor,
+    ConversionPatternRewriter& rewriter) const override
+  {
+    const auto loc = op->getLoc();
+    const auto module = op->getParentOfType<mlir::ModuleOp>();
+
+    // Determine which operand is the interface value.
+    mlir::Value interfaceValue;
+    mlir::Value otherValue;
+    mlir::Type otherType;
+
+    if (mlir::go::isa<mlir::go::InterfaceType>(op.getLhs().getType()))
+    {
+      interfaceValue = adaptor.getLhs();
+      otherValue = adaptor.getRhs();
+      otherType = op.getRhs().getType();
+    }
+    else
+    {
+      interfaceValue = adaptor.getRhs();
+      otherValue = adaptor.getLhs();
+      otherType = op.getLhs().getType();
+    }
+
+    // Create the runtime call to compare the interface value depending on the type of the "other"
+    // value.
+    mlir::Value result;
+    if (mlir::go::isa<mlir::go::InterfaceType>(otherType))
+    {
+      // Emit the runtime call to do an interface to interface comparison.
+      result = createRuntimeCall(
+        rewriter,
+        op.getLoc(),
+        "interfaceCompare",
+        this->getTypeConverter(),
+        { interfaceValue, otherValue })[0];
+    }
+    else
+    {
+      mlir::Value addr;
+      {
+        mlir::OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(op->getBlock());
+        const mlir::Value oneValue =
+          rewriter.create<mlir::LLVM::ConstantOp>(loc, rewriter.getI64Type(), 1);
+        addr = rewriter.create<mlir::LLVM::AllocaOp>(
+          loc, this->getVoidPtrType(), otherValue.getType(), oneValue);
+      }
+
+      // Store a copy of the other value.
+      // TODO: Need a slick way of getting the allocation associated with this value.
+      rewriter.create<mlir::LLVM::StoreOp>(loc, otherValue, addr);
+
+      // Get information about the other type.
+      auto typeInfoGlobalOp = createTypeInfo(rewriter, module, loc, otherType);
+      const Value infoValue = rewriter.create<mlir::LLVM::AddressOfOp>(loc, typeInfoGlobalOp);
+
+      // Emit the runtime call to do an interface to arbitrary value comparison.
+      result = createRuntimeCall(
+        rewriter,
+        loc,
+        "interfaceCompareTo",
+        this->getTypeConverter(),
+        { interfaceValue, infoValue, addr })[0];
+    }
+
+    // Replace the operation.
+    rewriter.replaceOp(op, result);
+
+    return success();
+  }
+};
+
 struct ZeroOpLowering : ConvertOpToLLVMPattern<ZeroOp>
 {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -1909,6 +1988,7 @@ void populateGoToLLVMConversionPatterns(
             transforms::LLVM::ChanSendOpLowering,
             transforms::LLVM::ChanRecvOpLowering,
             transforms::LLVM::ConstantOpLowering,
+            transforms::LLVM::CmpInterfaceOpLowering,
             transforms::LLVM::DeferOpLowering,
             transforms::LLVM::ExtractOpLowering,
             transforms::LLVM::GetElementPointerOpLowering,


### PR DESCRIPTION
compiler/ssa:
Replaced runtime calls for interface comparisons with explicit operation.
Fixed bug in variable declaration IR generation where there was no conversion for the initializer value for interface types.

goir:
Implemented operation for comparisons involving interface types.
Improved heap escape analysis pass to reduce unnecessary heap escapes involving interface values.
