### PR TITLE
Implement support for deferred function, method and interface method …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ configure: configure-llvm configure-goir
 
 reconfigure:
 	rm -f $(LLVM_CMAKE_CACHE) $(GOIR_CMAKE_CACHE)
-	$(MAKE) configure
+	"$(MAKE)" configure
 
 generate-llvm-bindings: ./llvm/llvm.go
 ./llvm/llvm.go: ./llvm/llvm.i

--- a/builder/build.go
+++ b/builder/build.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -212,22 +211,17 @@ func Build(ctx context.Context, packageDir string) error {
 	builder.GeneratePackages(ctx, program.OrderedPackages)
 	fmt.Println("done")
 
-	// dump the module to a string
-	fname, _ := filepath.Abs(options.Output + ".dump.mlir")
+	// Create the output directory.
+	outputDir := filepath.Dir(options.Output)
+	if _, err := os.Stat(outputDir); errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(outputDir, 0750); err != nil {
+			return err
+		}
+	}
 
 	// Post IR generation:
 	if options.DumpIR {
-
-		// The path to the output must exist. Create it if it doesn't
-		if stat, err := os.Stat(path.Dir(fname)); errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(path.Dir(fname), 0750); err != nil {
-				return err
-			}
-		} else if !stat.IsDir() {
-			return os.ErrInvalid
-		}
-
-		mlir.ModuleDumpToFile(mlirModule, fname)
+		mlir.ModuleDumpToFile(mlirModule, options.Output+".dump.mlir")
 	}
 
 	// Run the optimization passes
@@ -235,7 +229,6 @@ func Build(ctx context.Context, packageDir string) error {
 	passDumpDir = filepath.Dir(passDumpDir)
 	passDumpName := filepath.Base(options.Output)
 	fmt.Print("Optimizing Go IR...")
-	// TODO: add switch for debug mode.
 	if mlir.LogicalResultIsFailure(mlir.GoOptimizeModule(mlirModule, passDumpName, passDumpDir, false)) {
 		fmt.Println()
 		return errors.Join(ErrCodeGeneratorError, err, errors.New("optimization passes failed"))
@@ -243,19 +236,7 @@ func Build(ctx context.Context, packageDir string) error {
 	fmt.Println("done")
 
 	if options.DumpIR {
-		// dump the module to a string
-		fname := options.Output + ".dump.llvm.mlir"
-
-		// The path to the output must exist. Create it if it doesn't
-		if stat, err := os.Stat(path.Dir(fname)); errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(path.Dir(fname), 0750); err != nil {
-				return err
-			}
-		} else if !stat.IsDir() {
-			return os.ErrInvalid
-		}
-
-		mlir.ModuleDumpToFile(mlirModule, fname)
+		mlir.ModuleDumpToFile(mlirModule, options.Output+".dump.llvm.mlir")
 	}
 
 	// Initialize the LLVMIR translator
@@ -431,16 +412,6 @@ func link(options Options, targetInfo targets.TargetInfo, arch string, float str
 }
 
 func dumpModule(module llvm.LLVMModuleRef, fname string) error {
-	// The path to the output must exist. Create it if it doesn't
-	if stat, err := os.Stat(path.Dir(fname)); errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(path.Dir(fname), 0750); err != nil {
-			return err
-		}
-	} else if !stat.IsDir() {
-		return os.ErrInvalid
-	}
-
-	// Finally, dump the module
 	llvm.PrintModuleToFile(module, fname, nil)
 	return nil
 }

--- a/builder/env.go
+++ b/builder/env.go
@@ -23,12 +23,9 @@ func Environment() (Env, error) {
 	}
 
 	// Get GOROOT from the system Go
-	cmd := exec.Command("go", "env", "GOROOT")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	goRoot := strings.TrimSpace(string(output))
+	goRoot := getgoenv("GOROOT", "")
+	goProxy := getgoenv("GOPROXY", "")
+	goModCache := getgoenv("GOMODCACHE", "")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -48,7 +45,9 @@ func Environment() (Env, error) {
 		"SIGOPATH":  getenv("SIGOPATH", getenv("GOPATH", cwd)),
 		"SIGOCACHE": getenv("SIGOCACHE", getenv("GOCACHE", filepath.Join(cacheDir, "go-build"))),
 
-		"GOROOT": getenv("GOROOT", goRoot),
+		"GOROOT":     getenv("GOROOT", goRoot),
+		"GOPROXY":    getenv("GOROOT", goProxy),
+		"GOMODCACHE": getenv("GOMODCACHE", goModCache),
 		//"GOPATH":   getenv("SIGOPATH", getenv("GOPATH", cwd)),
 		"GOCACHE":  getenv("SIGOCACHE", getenv("GOCACHE", filepath.Join(cacheDir, "go-build"))),
 		"GOTMPDIR": getenv("SIGOTMPDIR", filepath.Join(cacheDir, "sigo")),
@@ -86,4 +85,17 @@ func getenv(key, _default string) (value string) {
 		value = _default
 	}
 	return value
+}
+
+func getgoenv(key, _default string) (value string) {
+	cmd := exec.Command("go", "env", key)
+	output, err := cmd.Output()
+	if err != nil {
+		panic(err)
+	}
+	value = strings.TrimSpace(string(output))
+	if len(value) == 0 {
+		value = _default
+	}
+	return
 }

--- a/compiler/ssa/builder.go
+++ b/compiler/ssa/builder.go
@@ -327,10 +327,6 @@ func (b *Builder) GeneratePackages(ctx context.Context, pkgs []*packages.Package
 					result := b.emitExpr(ctx, initializer.Rhs)[0]
 
 					if rhsType != nil {
-						if T, ok := rhsType.(*types.Named); ok {
-							b.queueNamedTypeJobs(ctx, T)
-						}
-
 						switch baseType(lhs.Type()).(type) {
 						case *types.Interface:
 							if !types.Identical(lhs.Type(), rhsType) {

--- a/compiler/ssa/call.go
+++ b/compiler/ssa/call.go
@@ -289,11 +289,6 @@ func (b *Builder) emitCallArgs(ctx context.Context, signature *types.Signature, 
 					// Convert from interface A to interface B.
 					argValues[i] = b.emitChangeType(ctx, paramT, argValues[i], location)
 				} else {
-					// Generate methods for named types.
-					if T, ok := argT.(*types.Named); ok {
-						b.queueNamedTypeJobs(ctx, T)
-					}
-
 					// Create an interface value from the value expression.
 					argValues[i] = b.emitInterfaceValue(ctx, paramT, argT, argValues[i], location)
 				}
@@ -536,11 +531,6 @@ func (b *Builder) emitVariadicArgs(ctx context.Context, signature *types.Signatu
 						// Convert from interface A to interface B.
 						arg = b.emitChangeType(ctx, elementType, arg, location)
 					} else {
-						// Generate methods for named types.
-						if T, ok := argT.(*types.Named); ok {
-							b.queueNamedTypeJobs(ctx, T)
-						}
-
 						// Create an interface value from the value expression.
 						arg = b.emitInterfaceValue(ctx, elementType, argT, arg, location)
 					}

--- a/compiler/ssa/emit.go
+++ b/compiler/ssa/emit.go
@@ -111,11 +111,6 @@ func (b *Builder) emitAssign(ctx context.Context, stmt *ast.AssignStmt) {
 							// Convert from interface A to interface B.
 							rhs = b.emitChangeType(ctx, lhsType, rhs, location)
 						} else {
-							// Generate methods for named types.
-							if T, ok := rhsType.(*types.Named); ok {
-								b.queueNamedTypeJobs(ctx, T)
-							}
-
 							// Create an interface value from the value expression.
 							rhs = b.emitInterfaceValue(ctx, lhsType, rhsType, rhs, location)
 						}
@@ -445,11 +440,6 @@ func (b *Builder) emitGenericDecl(ctx context.Context, decl *ast.GenDecl) {
 						// Convert from interface A to interface B.
 						result = b.emitChangeType(ctx, lhsType, result, location)
 					} else {
-						// Generate methods for named types.
-						if T, ok := rhsType.(*types.Named); ok {
-							b.queueNamedTypeJobs(ctx, T)
-						}
-
 						// Create an interface value from the value expression.
 						result = b.emitInterfaceValue(ctx, lhsType, rhsType, result, location)
 					}
@@ -682,11 +672,6 @@ func (b *Builder) emitReturn(ctx context.Context, stmt *ast.ReturnStmt) {
 							// Convert from interface A to interface B.
 							v[ii] = b.emitChangeType(ctx, returnType, v[ii], location)
 						} else {
-							// Generate methods for named types.
-							if T, ok := valueType.(*types.Named); ok {
-								b.queueNamedTypeJobs(ctx, T)
-							}
-
 							// Create an interface value from the value expression.
 							v[ii] = b.emitInterfaceValue(ctx, returnType, valueType, v[ii], location)
 						}

--- a/compiler/ssa/lit.go
+++ b/compiler/ssa/lit.go
@@ -64,11 +64,6 @@ func (b *Builder) emitArrayLiteral(ctx context.Context, expr *ast.CompositeLit) 
 					// Convert from interface A to interface B.
 					elementValue = b.emitChangeType(ctx, elementT, elementValue, location)
 				} else {
-					// Generate methods for named types.
-					if T, ok := valueT.(*types.Named); ok {
-						b.queueNamedTypeJobs(ctx, T)
-					}
-
 					// Create an interface value from the value expression.
 					elementValue = b.emitInterfaceValue(ctx, elementT, valueT, elementValue, location)
 				}
@@ -119,11 +114,6 @@ func (b *Builder) emitMapLiteral(ctx context.Context, expr *ast.CompositeLit) ml
 					// Convert from interface A to interface B.
 					keyValue = b.emitChangeType(ctx, keyT, keyValue, location)
 				} else {
-					// Generate methods for named types.
-					if T, ok := valueT.(*types.Named); ok {
-						b.queueNamedTypeJobs(ctx, T)
-					}
-
 					// Create an interface value from the value expression.
 					keyValue = b.emitInterfaceValue(ctx, keyT, valueT, keyValue, location)
 				}
@@ -138,11 +128,6 @@ func (b *Builder) emitMapLiteral(ctx context.Context, expr *ast.CompositeLit) ml
 					// Convert from interface A to interface B.
 					elementValue = b.emitChangeType(ctx, elementT, elementValue, location)
 				} else {
-					// Generate methods for named types.
-					if T, ok := valueT.(*types.Named); ok {
-						b.queueNamedTypeJobs(ctx, T)
-					}
-
 					// Create an interface value from the value expression.
 					elementValue = b.emitInterfaceValue(ctx, elementT, valueT, elementValue, location)
 				}
@@ -184,11 +169,6 @@ func (b *Builder) emitSliceLiteral(ctx context.Context, expr *ast.CompositeLit) 
 					// Convert from interface A to interface B.
 					elementValue = b.emitChangeType(ctx, elementT, elementValue, location)
 				} else {
-					// Generate methods for named types.
-					if T, ok := valueT.(*types.Named); ok {
-						b.queueNamedTypeJobs(ctx, T)
-					}
-
 					// Create an interface value from the value expression.
 					elementValue = b.emitInterfaceValue(ctx, elementT, valueT, elementValue, location)
 				}
@@ -268,11 +248,6 @@ func (b *Builder) emitStructLiteral(ctx context.Context, expr *ast.CompositeLit)
 					// Convert from interface A to interface B.
 					elementValue = b.emitChangeType(ctx, fieldT, elementValue, elementLoc)
 				} else {
-					// Generate methods for named types.
-					if T, ok := valueT.(*types.Named); ok {
-						b.queueNamedTypeJobs(ctx, T)
-					}
-
 					// Create an interface value from the value expression.
 					elementValue = b.emitInterfaceValue(ctx, fieldT, valueT, elementValue, elementLoc)
 				}

--- a/compiler/ssa/values.go
+++ b/compiler/ssa/values.go
@@ -252,6 +252,16 @@ func (b *Builder) emitInterfaceValue(ctx context.Context, T types.Type, valueTyp
 		addr = b.makeCopyOf(ctx, value, location)
 	}
 
+	// Generate methods for named types.
+	switch valueType := valueType.(type) {
+	case *types.Named:
+		b.queueNamedTypeJobs(ctx, valueType)
+	case *types.Pointer:
+		if T, ok := valueType.Elem().(*types.Named); ok {
+			b.queueNamedTypeJobs(ctx, T)
+		}
+	}
+
 	// Create the interface value.
 	interfaceT := b.GetType(ctx, T)
 	dynamicT := b.GetType(ctx, valueType)

--- a/goir/include/Go/IR/Operations/Call.td
+++ b/goir/include/Go/IR/Operations/Call.td
@@ -29,7 +29,7 @@ def CallOp : Go_Op<"call"> {
 //===----------------------------------------------------------------------===//
 
 def CallIndirectOp : Go_Op<"call_indirect"> {
-    let arguments = (ins Go_Addressable:$callee, Variadic<Go_Type>:$callee_operands);
+    let arguments = (ins Go_Pointer:$callee, Variadic<Go_Type>:$callee_operands);
     let results = (outs Variadic<Go_Type>:$results);
     let assemblyFormat = [{
         $callee `<` type($callee) `>` `(` $callee_operands `)` attr-dict `:` functional-type($callee_operands, results)
@@ -53,7 +53,7 @@ def DeferOp : Go_Op<"call_defer"> {
         ``
     }];
     let arguments = (ins
-                AnyTypeOrNamedOf<[Go_Function, Go_Interface, Go_Struct]>:$callee,
+                AnyTypeOrNamedOf<[Go_Interface, Go_Struct, Go_Pointer]>:$callee,
                 OptionalAttr<StrAttr>:$method_name,
                 Variadic<Go_Type>:$callee_operands);
     let assemblyFormat = [{
@@ -77,7 +77,7 @@ def GoOp : Go_Op<"call_go"> {
         ```
     }];
     let arguments = (ins
-            AnyTypeOrNamedOf<[Go_Addressable, Go_Interface, Go_Struct]>:$callee,
+            AnyTypeOrNamedOf<[Go_Interface, Go_Struct, Go_Pointer]>:$callee,
             Variadic<Go_Type>:$callee_operands,
             TypeAttr:$signature,
             OptionalAttr<StrAttr>:$method_name);

--- a/goir/include/Go/Util.h
+++ b/goir/include/Go/Util.h
@@ -46,7 +46,7 @@ GoTypeId GetGoTypeId(const mlir::Type& type);
 
 std::string typeStr(const mlir::Type &T);
 
-llvm::hash_code computeMethodHash(const StringRef name, const FunctionType func, bool isInterface);
+llvm::hash_code computeMethodHash(const StringRef name, const mlir::TypeRange inputs, const mlir::TypeRange outputs);
 
 inline uint64_t alignTo(uint64_t value, uint64_t alignment) { return (value + alignment - 1) / alignment * alignment; }
 

--- a/goir/lib/CAPI/mlir/Dialects.cxx
+++ b/goir/lib/CAPI/mlir/Dialects.cxx
@@ -116,10 +116,10 @@ bool mlirModuleDumpToFile(MlirModule module, MlirStringRef fname)
   auto _fname = unwrap(fname);
 
   std::error_code EC;
-  ::llvm::raw_fd_ostream dest(_fname, EC, llvm::sys::fs::OF_TextWithCRLF);
+  ::llvm::raw_fd_ostream dest(_fname, EC, llvm::sys::fs::OF_Text);
   if (EC)
   {
-    //*ErrorMessage = strdup(EC.message().c_str());
+    llvm::errs() << EC.message() << "\n";
     return false;
   }
 
@@ -129,8 +129,7 @@ bool mlirModuleDumpToFile(MlirModule module, MlirStringRef fname)
 
   if (dest.has_error())
   {
-    // std::string E = "Error printing to file: " + dest.error().message();
-    //*ErrorMessage = strdup(E.c_str());
+    llvm::errs() << EC.message() << "\n";
     return false;
   }
 

--- a/goir/lib/Go/IR/Operations/Call.cxx
+++ b/goir/lib/Go/IR/Operations/Call.cxx
@@ -52,10 +52,10 @@ namespace mlir::go
       .Case(
         [&](PointerType T) -> LogicalResult
         {
-          if (auto elementType = T.getElementType())
+          if (auto elementType = T.getElementType(); elementType.has_value())
           {
             // Must be a pointer to a function.
-            if (mlir::go::isa<FunctionType>(*elementType))
+            if (mlir::go::isa<mlir::go::FunctionType>(*elementType))
             {
               Fn = mlir::go::dyn_cast<mlir::go::FunctionType>(*elementType);
               return success();

--- a/goir/lib/Go/Transforms/CallPass.cxx
+++ b/goir/lib/Go/Transforms/CallPass.cxx
@@ -1,6 +1,7 @@
 #include <llvm/ADT/TypeSwitch.h>
 
 #include <mlir/Conversion/LLVMCommon/Pattern.h>
+#include <mlir/Dialect/Ptr/IR/PtrOpsDialect.h.inc>
 #include <mlir/Pass/Pass.h>
 
 #include "Go/IR/GoOps.h"
@@ -8,9 +9,166 @@
 
 namespace mlir::go
 {
+
 struct CallPass : public mlir::PassWrapper<CallPass, mlir::OperationPass<mlir::ModuleOp>>
 {
   llvm::SmallDenseMap<llvm::hash_code, std::string> m_thunkSymbols;
+  llvm::SmallDenseMap<llvm::hash_code, std::string> m_wrapperSymbols;
+
+  std::pair<mlir::FlatSymbolRefAttr, mlir::Value> createCallWrapper(
+    mlir::OpBuilder& builder,
+    mlir::ModuleOp module,
+    const mlir::Location loc,
+    mlir::Value callee,
+    mlir::ValueRange args,
+    mlir::StringAttr method = mlir::StringAttr())
+  {
+    const auto ptrType = builder.getType<mlir::go::PointerType>(std::nullopt);
+
+    SmallVector<mlir::Value> calleeArgs;
+    mlir::Value calleeValue;
+    bool isInterface = false;
+    mlir::Type interfaceType;
+
+    mlir::TypeRange resultTypes;
+    mlir::TypeSwitch<mlir::Type>(mlir::go::baseType(callee.getType()))
+      .Case(
+        [&](const InterfaceType& type)
+        {
+          isInterface = true;
+          calleeValue = callee;
+          interfaceType = type;
+
+          const auto methodSignature =
+            mlir::cast<mlir::go::FunctionType>(type.getMethods()[method.str()]);
+          resultTypes = methodSignature.getResults();
+        })
+      .Case(
+        [&](const PointerType& type)
+        {
+          calleeValue = callee;
+          const auto calleeType = *type.getElementType();
+          const auto calleeSignature =
+            mlir::dyn_cast_or_null<mlir::go::FunctionType>(mlir::go::baseType(calleeType));
+          resultTypes = calleeSignature.getResults();
+        })
+      .Case(
+        [&](const GoStructType& type)
+        {
+          // TODO: Probably should represent this one by some closure type.
+          calleeValue = builder.create<ExtractOp>(loc, ptrType, 0, callee);
+          mlir::Value argsPtrValue = builder.create<ExtractOp>(loc, ptrType, 1, callee);
+
+          // Prepend the previous arguments pointer value to the argument list.
+          calleeArgs.push_back(argsPtrValue);
+        })
+      .Default([&](const mlir::Type&) { assert(false && "unhandled callee type"); });
+
+    // Append the incoming call arguments.
+    calleeArgs.append(args.begin(), args.end());
+
+    // Collect all the callee arg types.
+    llvm::hash_code argsHash = llvm::hash_value(isInterface);
+    SmallVector<std::tuple<mlir::StringAttr, mlir::Type, mlir::StringAttr>> ctxStructTypes;
+    ctxStructTypes.emplace_back(
+      builder.getStringAttr(""), calleeValue.getType(), builder.getStringAttr(""));
+
+    // Hash and add the argument value types.
+    for (const auto& arg : calleeArgs)
+    {
+      // Hash the type's unique storage pointer value.
+      argsHash = llvm::hash_value(arg.getType().getImpl());
+      ctxStructTypes.emplace_back(
+        builder.getStringAttr(""), arg.getType(), builder.getStringAttr(""));
+    }
+
+    // Create a struct type for these call arguments.
+    const auto ctxStructType =
+      mlir::go::GoStructType::getLiteral(builder.getContext(), ctxStructTypes);
+
+    // Create the context struct value.
+    mlir::Value ctxValue = builder.create<mlir::go::ZeroOp>(loc, ctxStructType);
+    ctxValue = builder.create<mlir::go::InsertOp>(loc, ctxStructType, calleeValue, 0, ctxValue);
+    for (size_t i = 0; i < calleeArgs.size(); i++)
+    {
+      ctxValue =
+        builder.create<mlir::go::InsertOp>(loc, ctxStructType, calleeArgs[i], i + 1, ctxValue);
+    }
+
+    std::string symbol;
+    if (const auto it = this->m_wrapperSymbols.find(argsHash); it == this->m_wrapperSymbols.end())
+    {
+      mlir::OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPointToStart(module.getBody());
+
+      // Format the wrapper symbol name.
+      symbol = "_call_wrapper_" + std::to_string(argsHash);
+
+      // Create the signature for this function.
+      auto signature = builder.getType<mlir::go::FunctionType>(
+        mlir::SmallVector<mlir::Type>{ ptrType }, resultTypes);
+
+      // Create a new call wrapper function.
+
+      {
+        auto funcOp = builder.create<FuncOp>(loc, symbol, signature);
+        auto entryBlock = funcOp.addEntryBlock();
+
+        mlir::OpBuilder::InsertionGuard guard2(builder);
+        builder.setInsertionPointToStart(entryBlock);
+        const mlir::Value closureValue = entryBlock->getArgument(0);
+
+        // Unpack the call arguments.
+        SmallVector<Value> callArgs(calleeArgs.size());
+        for (int32_t i = 0; i < static_cast<int32_t>(callArgs.size()); ++i)
+        {
+          const auto argType = calleeArgs[i].getType();
+          Value callArgPtr = builder.create<GetElementPointerOp>(
+            loc,
+            ptrType,
+            closureValue,
+            ctxStructType,
+            ValueRange{},
+            SmallVector<int32_t>{ 0, i + 1 });
+          callArgs[i] = builder.create<LoadOp>(loc, argType, callArgPtr, UnitAttr(), UnitAttr());
+        }
+
+        mlir::ValueRange results;
+        if (isInterface)
+        {
+          // Unpack the interface receiver value.
+          Value interfaceValue =
+            builder.create<LoadOp>(loc, interfaceType, closureValue, UnitAttr(), UnitAttr());
+
+          // Call the function being wrapped.
+          results =
+            builder.create<InterfaceCallOp>(loc, resultTypes, method, interfaceValue, callArgs)
+              .getResults();
+        }
+        else
+        {
+          // Unpack the callee function pointer.
+          Value funcPtr =
+            builder.create<LoadOp>(loc, ptrType, closureValue, UnitAttr(), UnitAttr());
+
+          // Call the function being wrapped.
+          results =
+            builder.create<CallIndirectOp>(loc, resultTypes, funcPtr, callArgs).getResults();
+        }
+
+        // Create return operation.
+        builder.create<mlir::go::ReturnOp>(loc, results);
+      }
+
+      // Cache this wrapper symbol.
+      this->m_wrapperSymbols[argsHash] = symbol;
+    }
+    else
+    {
+      symbol = it->second;
+    }
+    return std::make_pair(builder.getAttr<mlir::FlatSymbolRefAttr>(symbol), ctxValue);
+  }
 
   void runOnOperation() final
   {
@@ -39,8 +197,7 @@ struct CallPass : public mlir::PassWrapper<CallPass, mlir::OperationPass<mlir::M
       builder.setInsertionPointToStart(module.getBody());
 
       // Note: Since thunks can be reused for calls with matching signature, no fixed location for
-      // the
-      //       resulting operations can be known.
+      // the resulting operations can be known.
       const auto loc = UnknownLoc::get(context);
 
       // Hash the call argument types.
@@ -179,6 +336,60 @@ struct CallPass : public mlir::PassWrapper<CallPass, mlir::OperationPass<mlir::M
     module.walk(
       [&](DeferOp deferOp)
       {
+        const auto loc = deferOp.getLoc();
+        std::optional<std::pair<mlir::FlatSymbolRefAttr, mlir::Value>> wrappedCallee;
+        OpBuilder builder(deferOp);
+        if (mlir::go::isa<mlir::go::GoStructType>(deferOp.getCallee().getType()))
+        {
+          if (deferOp.getCalleeOperands().size() > 0)
+          {
+            // Create a call wrapper for any previously wrapped call that specifies more arguments.
+            wrappedCallee = createCallWrapper(
+              builder,
+              module,
+              deferOp.getLoc(),
+              deferOp.getCallee(),
+              deferOp.getCalleeOperands(),
+              deferOp.getMethodNameAttr());
+          }
+        }
+        else
+        {
+          wrappedCallee = createCallWrapper(
+            builder,
+            module,
+            deferOp.getLoc(),
+            deferOp.getCallee(),
+            deferOp.getCalleeOperands(),
+            deferOp.getMethodNameAttr());
+        }
+
+        if (wrappedCallee.has_value())
+        {
+          const auto symbol = wrappedCallee.value().first;
+          const auto args = wrappedCallee.value().second;
+
+          // Get the call wrapper function by symbol.
+          Value funcPtr = builder.create<AddressOfOp>(loc, ptrType, symbol);
+
+          // Allocate memory to store the call args.
+          Value argsPtr = builder.create<AllocaOp>(
+            loc, ptrType, args.getType(), 1, builder.getUnitAttr(), StringAttr());
+          builder.create<StoreOp>(loc, args, argsPtr, UnitAttr(), UnitAttr());
+
+          // Create the func value.
+          mlir::Value funcValue = builder.create<ZeroOp>(loc, funcType);
+          funcValue = builder.create<InsertOp>(loc, funcType, funcPtr, 0, funcValue);
+          funcValue = builder.create<InsertOp>(loc, funcType, argsPtr, 1, funcValue);
+
+          // Replace the defer op call.
+          const auto newDeferOp =
+            builder.create<DeferOp>(loc, funcValue, mlir::StringAttr(), mlir::ValueRange());
+          deferOp->erase();
+          deferOp = newDeferOp;
+        }
+
+        // Handle RunDefersOp insertion for the parent function.
         auto parentFunction = deferOp->getParentOfType<mlir::go::FuncOp>();
         if (visitedFuncs.contains(parentFunction))
         {
@@ -384,4 +595,5 @@ std::unique_ptr<mlir::Pass> createCallPass()
 {
   return std::make_unique<CallPass>();
 }
+
 } // namespace mlir::go

--- a/goir/lib/Go/Transforms/LowerToLLVM.cxx
+++ b/goir/lib/Go/Transforms/LowerToLLVM.cxx
@@ -1770,7 +1770,8 @@ struct InterfaceCallOpLowering : ConvertOpToLLVMPattern<InterfaceCallOp>
     // Compute method hash (method name, args types, result types)
     const auto signature = mlir::cast<FunctionType>(
       cast<InterfaceType>(op.getIface().getType()).getMethods().at(adaptor.getCallee().str()));
-    auto methodHash = uint32_t(computeMethodHash(adaptor.getCallee(), signature, true));
+    auto methodHash = static_cast<uint32_t>(
+      computeMethodHash(adaptor.getCallee(), signature.getInputs(), signature.getResults()));
     for (size_t i = 0; i < adaptor.getCalleeOperands().size(); ++i)
     {
       auto arg = adaptor.getCalleeOperands()[i];

--- a/goir/lib/Go/Transforms/TypeInfo.cxx
+++ b/goir/lib/Go/Transforms/TypeInfo.cxx
@@ -181,37 +181,6 @@ mlir::go::LLVMTypeConverter getLLVMTypeConverter(mlir::ModuleOp module)
   return mlir::go::LLVMTypeConverter(module, options);
 }
 
-llvm::hash_code computeLLVMFunctionHash(
-  const StringRef name,
-  const mlir::LLVM::LLVMFunctionType func,
-  bool isInterface)
-{
-  llvm::hash_code result = llvm::hash_value(name);
-  size_t offset = 0;
-  if (!isInterface)
-  {
-    // Skip the receiver for named-type methods.
-    offset = 1;
-  }
-
-  // Hash the input types starting at the offset.
-  for (size_t i = offset; i < func.getNumParams(); i++)
-  {
-    std::string str;
-    llvm::raw_string_ostream(str) << func.getParams()[i];
-    result = llvm::hash_combine(result, str);
-  }
-
-  // Hash the result types
-  for (auto t : func.getReturnTypes())
-  {
-    std::string str;
-    llvm::raw_string_ostream(str) << t;
-    result = llvm::hash_combine(result, str);
-  }
-  return result;
-}
-
 mlir::LLVM::GlobalOp createSignatureDataGlobal(
   mlir::OpBuilder& builder,
   mlir::ModuleOp module,
@@ -437,7 +406,7 @@ mlir::LLVM::GlobalOp createTypeInfo(
               for (auto [name, _func] : methods)
               {
                 const auto func = mlir::cast<FunctionType>(_func);
-                const auto id = computeMethodHash(name, func, true);
+                const auto id = computeMethodHash(name, func.getInputs(), func.getResults());
                 const auto interfaceMethodSymbol =
                   typeInfoSymbol(type, "_interface_method_" + name + "_" + std::to_string(id));
                 const auto interfaceMethodDataType =
@@ -538,9 +507,7 @@ mlir::LLVM::GlobalOp createTypeInfo(
               continue;
             }
 
-            if (
-              mlir::TypeAttr originalTypeAttr =
-                funcOp->getAttrOfType<mlir::TypeAttr>("originalType"))
+            if (auto originalTypeAttr = funcOp->getAttrOfType<mlir::TypeAttr>("originalType"))
             {
               fnT = mlir::dyn_cast<mlir::go::FunctionType>(originalTypeAttr.getValue());
             }
@@ -550,7 +517,8 @@ mlir::LLVM::GlobalOp createTypeInfo(
             // Compute the hash id for the type method.
             auto methodName = funcSymbol.getValue();
             methodName = methodName.substr(methodName.find_last_of(".") + 1);
-            const auto methodHashId = computeMethodHash(methodName, fnT, false);
+            const auto methodHashId =
+              computeMethodHash(methodName, fnT.getInputs(), fnT.getResults());
 
             // Create the type info for this function's signature.
             auto signatureTypeDataGlobalOp = createSignatureDataGlobal(builder, module, loc, fnT);

--- a/goir/lib/Go/Util.cxx
+++ b/goir/lib/Go/Util.cxx
@@ -71,31 +71,22 @@ std::string typeStr(const mlir::Type& T)
 }
 
 llvm::hash_code
-computeMethodHash(const StringRef name, const FunctionType func, bool isInterface)
+computeMethodHash(const StringRef name, const mlir::TypeRange inputs, const mlir::TypeRange outputs)
 {
   llvm::hash_code result = llvm::hash_value(name);
-  size_t offset = 0;
-  if (!isInterface)
-  {
-    // Skip the receiver for named-type methods.
-    offset = 1;
-  }
 
-  // Hash the input types starting at the offset.
-  for (size_t i = offset; i < func.getNumInputs(); i++)
+  // Hash the input types.
+  for (const auto& t : inputs)
   {
-    std::string str;
-    llvm::raw_string_ostream(str) << func.getInput(i);
-    result = llvm::hash_combine(result, str);
+    result = llvm::hash_combine(result, t.getImpl());
   }
 
   // Hash the result types
-  for (auto t : func.getResults())
+  for (auto t : outputs)
   {
-    std::string str;
-    llvm::raw_string_ostream(str) << t;
-    result = llvm::hash_combine(result, str);
+    result = llvm::hash_combine(result, t);
   }
+
   return result;
 }
 

--- a/src/runtime/arm/cortexm/platform.S
+++ b/src/runtime/arm/cortexm/platform.S
@@ -1,10 +1,10 @@
 .global runtime.exec
 .type runtime.exec, %function
 runtime.exec:
-		mov r4, lr
+	mov r4, lr
     blx r1
-		mov lr, r4
-		bx lr
+	mov lr, r4
+	bx lr
 .size runtime.exec, .-runtime.exec
 
 .global runtime.currentStack

--- a/src/runtime/arm/cortexm/qemu/cortexm4/isr-vector.s
+++ b/src/runtime/arm/cortexm/qemu/cortexm4/isr-vector.s
@@ -1,3 +1,6 @@
+.syntax unified
+
+// This is the default handler for interrupts, if triggered but not defined.
 .section .text.Default_Handler
 .global  Default_Handler
 .type    Default_Handler, %function
@@ -22,30 +25,30 @@ __isr_vector:
     // On reset, SP is initialized with *0x0 and PC is loaded with *0x4, loading
     // _stack_top and Reset_Handler.
     .long __stack
-	.long Reset_Handler
-	.long NonMaskableInt_Handler
-	.long HardFault_Handler
-	.long 0
-	.long 0
-	.long 0
-	.long 0
-	.long 0
-	.long 0
-	.long 0
-	.long SVCall_Handler
-	.long 0
-	.long 0
-	.long PendSV_Handler
-	.long SysTick_Handler
-	.long SYSTEM_Handler
-	.long WDT_Handler
+	.word  Reset_Handler
+    .word  NMI_Handler
+    .word  HardFault_Handler
+    .word  MemManage_Handler
+    .word  BusFault_Handler
+    .word  UsageFault_Handler
+    .word  0
+    .word  0
+    .word  0
+    .word  0
+    .word  SVCall_Handler
+    .word  DebugMonitor_Handler
+    .word  0
+    .word  PendSV_Handler
+    .word  SysTick_Handler
 
 	IRQ Reset_Handler
-    IRQ NonMaskableInt_Handler
+    IRQ NMI_Handler
     IRQ HardFault_Handler
+    IRQ MemManage_Handler
+    IRQ BusFault_Handler
+    IRQ UsageFault_Handler
     IRQ SVCall_Handler
+    IRQ DebugMonitor_Handler
     IRQ PendSV_Handler
     IRQ SysTick_Handler
-    IRQ SYSTEM_Handler
-    IRQ WDT_Handler
 

--- a/src/runtime/arm/cortexm/qemu/cortexm4/platform.go
+++ b/src/runtime/arm/cortexm/qemu/cortexm4/platform.go
@@ -1,0 +1,10 @@
+package cortexm4
+
+import (
+	"runtime/arm/cortexm"
+)
+
+func init() {
+	cortexm.SYSTICK_FREQUENCY = 168_000_000
+	cortexm.NPRIORITY_BITS = 3
+}

--- a/src/runtime/arm/cortexm/qemu/cortexm4/target.ld
+++ b/src/runtime/arm/cortexm/qemu/cortexm4/target.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-	FLASH (rw) : ORIGIN = 0x0, LENGTH = 512K
-	RAM (rw) : ORIGIN = 0x20000000, LENGTH = 512K
+	FLASH (rw) : ORIGIN = 0x08000000, LENGTH = 1024K
+	RAM (rw) : ORIGIN = 0x20000000, LENGTH = 192K
 }
 __stack_size = 4K;
 INCLUDE program.ld

--- a/src/runtime/arm/cortexm/tasks.S
+++ b/src/runtime/arm/cortexm/tasks.S
@@ -1,9 +1,9 @@
 .global _task_start
 .type _task_start, %function
 _task_start:
-    push {r2}                       // Save the task pointer on the stack
+    mov r4, r2                      // Save the task pointer in R4 save so that it is preserved cross
     blx r1                          // Start the goroutine. The parameters are already on R0
-    pop {r0}                        // Pop the task pointer into R0 as the parameter to removeTask
+    mov r2, r4                      // Move the task pointer back into R0 as the parameter to removeTask
     bl runtime.removeTask           // Remove this task from the scheduler
     bl runtime.schedulerPause       // Run another task for the remainder of this SysTick
 .loop:                              // ---------------------------


### PR DESCRIPTION
…calls.

builder:
The output directory is now created immediately after successful SSA generation. Capture GORPROXY and GOROOT from `go env`.

compiler/ssa:
Fixed bug where the methods of aliased types were not being generated when a pointer value is converted to an interface value.

goir:
Refactored call wrapper function generator to support more scenarios. Refactored method hash function to so that the result hash value is consistent between interface method signatures and type alias method signatures.

runtime:
Refactored out push and pop instructions from the implementations of `runtime.exec` and `runtime.taskStart` for ARM that were causing issues with visualizing the backtrace with GDB. QEMU target for Cortex-M4F is now functional.

other:
Correct `reconfigure` target in Makefile where the nested make call required double quotes on Windows.