### PR TITLE
Implemented support for deferring builtin function calls.

### DIFF
--- a/compiler/ssa/builder.go
+++ b/compiler/ssa/builder.go
@@ -58,6 +58,9 @@ type Builder struct {
 	thunks     map[string]struct{}
 	thunkTypes map[string]mlir.Type
 
+	builtinWrapperMutex sync.Mutex
+	builtinWrappers     map[string]string
+
 	// Misc:
 	generateQueue      chan *funcData
 	work               atomic.Int32
@@ -99,16 +102,17 @@ type jobQueue struct {
 
 func NewBuilder(config Config) *Builder {
 	builder := &Builder{
-		config:        config,
-		typeCache:     map[types.Type]mlir.Type{},
-		valueCache:    map[types.Object]Value{},
-		ctx:           config.Ctx,
-		program:       config.Program,
-		symbols:       mlir.SymbolTableCreate(mlir.ModuleGetOperation(config.Module)),
-		generateQueue: make(chan *funcData),
-		thunks:        map[string]struct{}{},
-		thunkTypes:    map[string]mlir.Type{},
-		genericFuncs:  map[string]*funcData{},
+		config:          config,
+		typeCache:       map[types.Type]mlir.Type{},
+		valueCache:      map[types.Object]Value{},
+		ctx:             config.Ctx,
+		program:         config.Program,
+		symbols:         mlir.SymbolTableCreate(mlir.ModuleGetOperation(config.Module)),
+		generateQueue:   make(chan *funcData),
+		thunks:          map[string]struct{}{},
+		thunkTypes:      map[string]mlir.Type{},
+		genericFuncs:    map[string]*funcData{},
+		builtinWrappers: map[string]string{},
 
 		declaredTypes: map[types.Type]struct{}{},
 

--- a/compiler/ssa/call.go
+++ b/compiler/ssa/call.go
@@ -459,7 +459,24 @@ func (b *Builder) emitDeferStatement(ctx context.Context, stmt *ast.DeferStmt) {
 		appendOperation(ctx, op)
 	case *ast.Ident:
 		// Evaluate the callee.
-		F := b.emitExpr(ctx, Fun)[0]
+		var F mlir.Value
+		switch Fun := stmt.Call.Fun.(type) {
+		case *ast.Ident:
+			info := currentInfo(ctx)
+			tv := info.Types[Fun]
+			if tv.IsBuiltin() {
+				symbol := b.emitBuiltinCallWrapper(ctx, Fun)
+
+				// Get the address of the builtin wrapper function.
+				signature := b.typeOf(ctx, Fun).(*types.Signature)
+				fptrType := b.funcPointerOf(ctx, signature)
+				F = b.addressOfSymbol(ctx, symbol, fptrType, location)
+			} else {
+				panic("unhandled")
+			}
+		default:
+			F = b.emitExpr(ctx, Fun)[0]
+		}
 
 		// Emit the goroutine operation.
 		op := mlir.GoCreateDeferOperation(b.ctx, F, nil, callArgs, location)

--- a/compiler/ssa/func.go
+++ b/compiler/ssa/func.go
@@ -497,3 +497,71 @@ func (b *Builder) unpackArgPack(ctx context.Context, argTypes []mlir.Type, pack 
 	}
 	return result
 }
+
+func (b *Builder) emitBuiltinCallWrapper(ctx context.Context, ident *ast.Ident) string {
+	b.builtinWrapperMutex.Lock()
+	defer b.builtinWrapperMutex.Unlock()
+
+	if symbol, ok := b.builtinWrappers[ident.Name]; ok {
+		return symbol
+	}
+
+	// Emit a wrapper function for this builtin.
+	signature := b.typeOf(ctx, ident).(*types.Signature)
+
+	// Collect the argument types.
+	paramTypes := make([]mlir.Type, signature.Params().Len())
+	for i := 0; i < signature.Params().Len(); i++ {
+		paramTypes[i] = b.GetStoredType(ctx, signature.Params().At(i).Type())
+	}
+
+	paramLocs := make([]mlir.Location, len(paramTypes))
+	fill(paramLocs, b._noLoc)
+
+	// Collect the result types.
+	resultTypes := make([]mlir.Type, signature.Results().Len())
+	for i := 0; i < signature.Results().Len(); i++ {
+		resultTypes[i] = b.GetStoredType(ctx, signature.Results().At(i).Type())
+	}
+
+	// Create the wrapper function body.
+	region := mlir.RegionCreate()
+	ctx = newContextWithRegion(ctx, region)
+
+	entryBlock := mlir.BlockCreate2(paramTypes, paramLocs)
+	mlir.RegionAppendOwnedBlock(region, entryBlock)
+	buildBlock(ctx, entryBlock, func() {
+		args := make([]mlir.Value, signature.Params().Len())
+		for i := 0; i < signature.Params().Len(); i++ {
+			args[i] = mlir.BlockGetArgument(entryBlock, i)
+		}
+
+		// Emit the builtin call into the wrapper function.
+		op := mlir.GoCreateBuiltInCallOperation(b.ctx, ident.Name, resultTypes, args, b._noLoc)
+		appendOperation(ctx, op)
+
+		// Return the results.
+		returnOp := mlir.GoCreateReturnOperation(b.ctx, resultsOf(op), b._noLoc)
+		appendOperation(ctx, returnOp)
+	})
+
+	// Create the function operation.
+	symbol := fmt.Sprintf("_builtin_wrapper_%s", ident.Name)
+	wrapperFuncT := b.createSignatureType(ctx, signature)
+	state := mlir.OperationStateGet("go.func", b._noLoc)
+	mlir.OperationStateAddOwnedRegions(state, []mlir.Region{region})
+	mlir.OperationStateAddAttributes(state, []mlir.NamedAttribute{
+		b.namedOf("function_type", mlir.TypeAttrGet(wrapperFuncT)),
+		b.namedOf("sym_name", mlir.StringAttrGet(b.ctx, symbol)),
+		b.namedOf("sym_visibility", mlir.StringAttrGet(b.ctx, "private")),
+	})
+
+	funcOp := mlir.OperationCreate(state)
+
+	// This operation will be added later safely.
+	b.addToModuleMutex.Lock()
+	b.addToModule[symbol] = funcOp
+	b.addToModuleMutex.Unlock()
+	b.builtinWrappers[ident.Name] = symbol
+	return symbol
+}


### PR DESCRIPTION
compiler/ssa:
Added emitter for builtin function wrapper functions. The defer statement will now generate a wrapper function when the callee is a builtin function.