### PR TITLE
Fix build issues when compiling for a Linux host.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,22 @@ ifeq ($(OS),Windows_NT)
 	CMAKE_CXX_FLAGS += -pthread -femulated-tls
 	CMAKE_CXX_STANDARD_LIBRARIES += -lpthread
 	CLANG_TARGET := x86_64-pc-windows-gnu
+	CC ?= clang
+	CXX ?= clang++
 	# NOTE: ld should be replaced with ld.lld directly on Windows since Go is dumb.
 else
 	CGO_LDFLAGS += -fuse-ld=lld -lrt -ldl -lpthread -lm -lz -ltinfo
+endif
+
+CMAKE_COMPILER_ARGS := -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX}
+CMAKE_COMPILER_TARGET_ARGS += -DCMAKE_C_COMPILER_TARGET=${CLANG_TARGET} -DCMAKE_CXX_COMPILER_TARGET=${CLANG_TARGET}
+CMAKE_LINKER_ARGS := -DCMAKE_LINKER_TYPE=DEFAULT
+
+# Override the linker based on pattern
+ifneq (,$(findstring ld.gold,$(LD)))
+	CMAKE_LINKER_ARGS := -DCMAKE_LINKER_TYPE=GOLD
+else ifneq (,$(findstring ld.lld,$(LD)))
+	CMAKE_LINKER_ARGS := -DCMAKE_LINKER_TYPE=LLD
 endif
 
 GOFLAGS +=
@@ -20,7 +33,7 @@ ifeq ($(SIGO_BUILD_RELEASE),0)
 	CMAKE_BUILD_TYPE := Debug
 else
 	CGO_CFLAGS += -Oz
-	CMAKE_BUILD_TYPE=Release
+	CMAKE_BUILD_TYPE := Release
 endif
 
 LLVM_BUILD_DIR=$(ROOT_DIR)/build/$(CMAKE_BUILD_TYPE)/llvm-build
@@ -88,21 +101,18 @@ ABS_SSA_TEST_EXE=$(ABS_BINDIR)/ssa_test$(EXECUTABLE_POSTFIX)
 DEBUG ?= 0
 
 define build-compiler-rt
-	cmake $(ROOT_DIR)/thirdparty/llvm-project/compiler-rt -G "Ninja" -B ./build/compiler-rt-$(1)-$(2) \
+	CC=${CC} CXX=${CXX} cmake $(ROOT_DIR)/thirdparty/llvm-project/compiler-rt -G "Ninja" -B ./build/Release/compiler-rt-$(1)-$(2) \
 		-DCMAKE_INSTALL_PREFIX=$(ROOT_DIR)/lib/compiler-rt/$(1)/$(2) \
+		${CMAKE_COMPILER_ARGS} \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
 		-DCMAKE_SYSTEM_NAME="Generic" \
-		-DCMAKE_C_COMPILER=clang \
 		-DCMAKE_C_COMPILER_TARGET=$(1) \
 		-DCMAKE_C_FLAGS="-nostdlib -march=$(2) $(3)" \
-		-DCMAKE_CXX_COMPILER=clang++ \
 		-DCMAKE_CXX_COMPILER_TARGET=$(1) \
 		-DCMAKE_CXX_FLAGS="-nostdlib -march=$(2) $(3)" \
 		-DCMAKE_ASM_COMPILER_TARGET=$(1) \
 		-DCMAKE_ASM_FLAGS="-march=$(2) $(3)" \
-		-DCMAKE_C_COMPILER_LAUNCHER=ccache \
-		-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
 		-DLLVM_CMAKE_DIR=$(LLVM_BUILD_DIR) \
 		-DCOMPILER_RT_OS_DIR="$(1)" \
 		-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
@@ -113,31 +123,28 @@ define build-compiler-rt
 		-DCOMPILER_RT_BUILD_XRAY=OFF \
 		-DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
-	cmake --build ./build/compiler-rt-$(1)-$(2) --target install
+	cmake --build ./build/Release/compiler-rt-$(1)-$(2) --target install
 endef
 
 define build-picolibc
-	cmake $(ROOT_DIR)/thirdparty/picolibc -G "Ninja" -B ./build/picolibc-$(1)-$(2) \
+	CC=${CC} CXX=${CXX} cmake $(ROOT_DIR)/thirdparty/picolibc -G "Ninja" -B ./build/Release/picolibc-$(1)-$(2) 	\
 		-DCMAKE_INSTALL_PREFIX=$(ROOT_DIR)/lib/picolibc/$(1)/$(2) \
+		${CMAKE_COMPILER_ARGS} \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=OFF \
 		-DCMAKE_SYSTEM_NAME="Generic" \
 		-DCMAKE_SYSTEM_PROCESSOR="arm" \
-		-DCMAKE_C_COMPILER=clang \
 		-DCMAKE_C_COMPILER_TARGET=$(1) \
 		-DCMAKE_C_FLAGS="-nostdlib -march=$(2) $(3)" \
-		-DCMAKE_CXX_COMPILER=clang++ \
 		-DCMAKE_CXX_COMPILER_TARGET=$(1) \
 		-DCMAKE_CXX_FLAGS="-nostdlib -march=$(2) $(3)" \
 		-DCMAKE_ASM_COMPILER_TARGET=$(1) \
 		-DCMAKE_ASM_FLAGS="-march=$(2) $(3)" \
-		-DCMAKE_C_COMPILER_LAUNCHER=ccache \
-		-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
 		-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
 		-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
 		-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
 		-DPICOLIBC_TLS=OFF
-	cmake --build ./build/picolibc-$(1)-$(2) --target install --parallel
+	cmake --build ./build/Release/picolibc-$(1)-$(2) --target install --parallel
 endef
 
 define build-test
@@ -193,25 +200,21 @@ clean-sigo:
 
 $(LLVM_CMAKE_CACHE):
 	@mkdir -p ${LLVM_BUILD_DIR}
-	cmake -G "Ninja" -B ${LLVM_BUILD_DIR} $(ROOT_DIR)/thirdparty/llvm-project/llvm 	\
-		-DCMAKE_C_COMPILER=clang 													\
-        -DCMAKE_C_COMPILER_TARGET=${CLANG_TARGET} 									\
-        -DCMAKE_CXX_COMPILER=clang++ 												\
-        -DCMAKE_CXX_COMPILER_TARGET=${CLANG_TARGET} 								\
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache 											\
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 										\
-        -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}"										\
-        -DCMAKE_CXX_STANDARD_LIBRARIES="${CMAKE_CXX_STANDARD_LIBRARIES}"			\
-        -DCMAKE_LINKER_TYPE=LLD 													\
-		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) 										\
-		-DLLVM_ENABLE_PROJECTS="llvm;mlir" 											\
-		-DLLVM_ENABLE_ASSERTIONS=ON 												\
-		-DLLVM_ENABLE_EXPENSIVE_CHECKS=ON 											\
-		-DLLVM_ENABLE_BACKTRACES=ON 												\
-		-DLLVM_TARGETS_TO_BUILD="${CMAKE_LLVM_COMPONENTS}" 							\
-		-DMLIR_INCLUDE_TESTS=OFF 													\
-		-DLLVM_INCLUDE_TESTS=OFF 													\
-		-DCOMPILER_RT_INCLUDE_TESTS=OFF 											\
+	CC=${CC} CXX=${CXX} LD=${LD} cmake -G "Ninja" -B ${LLVM_BUILD_DIR} $(ROOT_DIR)/thirdparty/llvm-project/llvm 	\
+		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		${CMAKE_COMPILER_ARGS} \
+		${CMAKE_COMPILER_TARGET_ARGS} \
+		${CMAKE_LINKER_ARGS} \
+        -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" \
+        -DCMAKE_CXX_STANDARD_LIBRARIES="${CMAKE_CXX_STANDARD_LIBRARIES}" \
+		-DLLVM_ENABLE_PROJECTS="llvm;mlir" \
+		-DLLVM_ENABLE_ASSERTIONS=ON \
+		-DLLVM_ENABLE_EXPENSIVE_CHECKS=ON \
+		-DLLVM_ENABLE_BACKTRACES=ON \
+		-DLLVM_TARGETS_TO_BUILD="${CMAKE_LLVM_COMPONENTS}" \
+		-DMLIR_INCLUDE_TESTS=OFF \
+		-DLLVM_INCLUDE_TESTS=OFF \
+		-DCOMPILER_RT_INCLUDE_TESTS=OFF \
 		-DCLANG_INCLUDE_TESTS=OFF
 
 configure-llvm: $(LLVM_CMAKE_CACHE)
@@ -220,17 +223,13 @@ build-llvm: configure-llvm
 	cmake --build ${LLVM_BUILD_DIR} -j$(NUM_JOBS)
 
 $(GOIR_CMAKE_CACHE):
-	cmake -G "Ninja" -B ${GOIR_BUILD_DIR} ${GOIR_ROOT}								\
-		-DCMAKE_C_COMPILER_TARGET=${CLANG_TARGET} 									\
-		-DCMAKE_C_COMPILER=clang 													\
-		-DCMAKE_CXX_COMPILER=clang++ 												\
-		-DCMAKE_CXX_COMPILER_TARGET=${CLANG_TARGET} 								\
-		-DCMAKE_C_COMPILER_LAUNCHER=ccache 											\
-		-DCMAKE_CXX_COMPILER_LAUNCHER=ccache 										\
-		-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" 										\
-		-DCMAKE_CXX_STANDARD_LIBRARIES="${CMAKE_CXX_STANDARD_LIBRARIES}"			\
-		-DCMAKE_LINKER_TYPE=LLD 													\
-		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) 										\
+	CC=${CC} CXX=${CXX} LD=${LD}  cmake -G "Ninja" -B ${GOIR_BUILD_DIR} ${GOIR_ROOT} \
+		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		${CMAKE_COMPILER_ARGS} \
+		${CMAKE_COMPILER_TARGET_ARGS} \
+		${CMAKE_LINKER_ARGS} \
+		-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" \
+		-DCMAKE_CXX_STANDARD_LIBRARIES="${CMAKE_CXX_STANDARD_LIBRARIES}" \
 		-DCMAKE_PREFIX_PATH=${LLVM_BUILD_DIR}/lib/cmake
 
 configure-goir: build-llvm $(GOIR_CMAKE_CACHE)
@@ -249,7 +248,7 @@ reconfigure:
 generate-llvm-bindings: ./llvm/llvm.go
 ./llvm/llvm.go: ./llvm/llvm.i
 	@echo "Generating LLVM bindings using SWIG..."
-	@swig -go -intgosize 64 -cgo \
+	@swig -DSWIGWORDSIZE64 -go -intgosize 64 -cgo \
 	-I$(ROOT_DIR)/build/llvm-build/lib/clang/16/include \
 	-I$(ROOT_DIR)/build/llvm-build/include \
 	-I$(ROOT_DIR)/build/llvm-headers/include \
@@ -265,7 +264,7 @@ clean-llvm-bindings:
 generate-clang-bindings: ./clang/clang.go
 ./clang/clang.go: ./clang/clang.i
 	@echo "Generating Clang bindings using SWIG..."
-	@swig -go -intgosize 64 -cgo \
+	@swig -DSWIGWORDSIZE64 -go -intgosize 64 -cgo \
 	-I$(ROOT_DIR)/build/llvm-build/lib/clang/16/include \
 	-I$(ROOT_DIR)/build/llvm-build/include \
 	-I$(ROOT_DIR)/build/llvm-build/include \
@@ -280,7 +279,7 @@ clean-clang-bindings:
 generate-mlir-bindings: ./mlir/mlir.go
 ./mlir/mlir.go: ./mlir/mlir.i $(GOIR_ROOT)/include/Go-c/mlir/Dialects.h $(GOIR_ROOT)/include/Go-c/mlir/Enums.h $(GOIR_ROOT)/include/Go-c/mlir/Operations.h $(GOIR_ROOT)/include/Go-c/mlir/Types.h
 	@echo "Generating MLIR bindings using SWIG..."
-	@swig -go -intgosize 64 -cgo \
+	@swig -DSWIGWORDSIZE64 -go -intgosize 64 -cgo \
 	-I$(ROOT_DIR)/build/llvm-build/lib/clang/16/include \
 	-I$(ROOT_DIR)/build/llvm-build/include \
 	-I${GOIR_ROOT}/include \

--- a/README.md
+++ b/README.md
@@ -5,19 +5,28 @@ NOTE: This compiler is under active development and will change often!
 
 ## Supported Architectures
 
-+ ARM Cortex-M0
++ ARM Cortex-M0+
 + ARM Cortex-M4
++ ARM Cortex-M7
 
 Others coming soon...
 
 ## Building
 
-NOTE: The Go compiler and Clang is required on PATH to build!
+System Requirements:
+1. The Go Compiler
+2. Clang (Recommended)
+   1. On Windows, only the `x86_64-pc-windows-gnu` variant of clang is compatible with Go.
 
 Run the following commands to create a debug build:
 ```shell
 git clone https://github.com/waj334/sigo.git --recurse-submodules
 cd ./sigo
+
+export CC=clang
+export CXX=clang++
+export LD=ld.lld
+
 make sigo
 make generate-csp
 make build-picolibc
@@ -27,8 +36,30 @@ make build-compiler-rt
 
 or release:
 ```shell
+export CC=clang
+export CXX=clang++
+export LD=ld.lld
+
 make release SIGO_BUILD_RELEASE=1
 ```
+
+### Selecting a toolchain
+
+The toolchain used for compilation can be specified like the following:
+```shell
+export CC=clang-20
+export CXX=clang++-20
+export LD=ld.lld-20
+
+make sigo
+make release SIGO_BUILD_RELEASE=1
+```
+
+Clang is the recommended build toolchain since it can cross compile for most target platforms. The GNU compiler suite 
+can be used but the correct variant of it must be selected when compiling the runtime libraries for each target 
+platform.
+
+**Note: If these values are omitted, then the default toolchain for the host system will be selected by CMake.**
 
 ## Compiling a firmware image
 A firmware image can be compiled using the `build` subcommand:
@@ -65,4 +96,4 @@ sigoc build -j8 --cpu atsame51g19a -O0 -g -o/path/to/output/firmware.elf ./examp
 + Enable "Developer Mode" to fix issues with creating symlinks during build directory staging.
 + Slow linking?
   + The Go compiler will use `ld` by default, but `ld.lld` can be renamed to `ld` (rename ld and copy ld.lld in its place) 
-    so Go will invoke it instead. Linking will be 100 times faster!
+    so Go will invoke it instead and linking the final application will be exponentially times faster!

--- a/builder/build.go
+++ b/builder/build.go
@@ -227,7 +227,7 @@ func Build(ctx context.Context, packageDir string) error {
 	// Create the output directory.
 	outputDir := filepath.Dir(options.Output)
 	if _, err := os.Stat(outputDir); errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(outputDir, 0750); err != nil {
+		if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
 			return err
 		}
 	}
@@ -357,6 +357,12 @@ func link(options Options, targetInfo targets.TargetInfo, arch string, float str
 				}
 				return ""
 			}(),
+			func() string {
+				if float == "nofp" {
+					return "-mfloat-abi=softfp"
+				}
+				return "-mfloat-abi=hard"
+			}(),
 			"-o", objFile}
 
 		// Append defines to the assembler arguments
@@ -385,7 +391,7 @@ func link(options Options, targetInfo targets.TargetInfo, arch string, float str
 		args = append(args, objFile)
 	}
 
-	// Invoke ld.lld to compile the final binary
+	// Invoke ld.lld to link the final binary image.
 	lldCmd := exec.Command(toolchain.LD, args...)
 	lldCmd.Stdout = nil
 	lldCmd.Stderr = os.Stderr

--- a/builder/staging.go
+++ b/builder/staging.go
@@ -29,7 +29,7 @@ func StageGoRoot(stageDir string, env Env) error {
 
 	// Create the directory for the standard library.
 	sigoStlPath := filepath.Join(sigoRootPath, "src")
-	err = os.MkdirAll(sigoStlPath, os.ModeDir)
+	err = os.MkdirAll(sigoStlPath, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func StageGoRoot(stageDir string, env Env) error {
 			}
 
 			// Create this directory.
-			err = os.MkdirAll(stagedPath, os.ModeDir)
+			err = os.MkdirAll(stagedPath, os.ModePerm)
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func StageGoRoot(stageDir string, env Env) error {
 				// Check if the directory does not already exist in the staging directory.
 				if _, err := os.Stat(stagedPath); errors.Is(err, os.ErrNotExist) {
 					// Create this directory.
-					err = os.MkdirAll(stagedPath, os.ModeDir)
+					err = os.MkdirAll(stagedPath, os.ModePerm)
 					if err != nil {
 						return err
 					}

--- a/cmd/csp-gen/main.go
+++ b/cmd/csp-gen/main.go
@@ -25,7 +25,7 @@ func init() {
 
 func main() {
 	// Create the output directory
-	if err := os.MkdirAll(outputDir, 0750); err != nil {
+	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
 		log.Fatal("file io error: ", err)
 	}
 
@@ -65,7 +65,7 @@ func main() {
 		outFile = filepath.Join(outFile, formatSymbol(p.Identifier, false), "peripheral.go")
 
 		// Create the directory structure for the group.
-		if err = os.MkdirAll(filepath.Dir(outFile), 0750); err != nil {
+		if err = os.MkdirAll(filepath.Dir(outFile), os.ModePerm); err != nil {
 			log.Fatal("file io error: ", err)
 		}
 
@@ -90,7 +90,7 @@ func main() {
 		outFile := filepath.Join(outputDir, "..", fmt.Sprintf("interrupts_%s.go", v.Identifier))
 
 		// Create the directory structure for the group.
-		if err = os.MkdirAll(filepath.Dir(outFile), 0750); err != nil {
+		if err = os.MkdirAll(filepath.Dir(outFile), os.ModePerm); err != nil {
 			log.Fatal("file io error: ", err)
 		}
 
@@ -115,7 +115,7 @@ func main() {
 	for _, v := range d.Variants {
 		outFile := filepath.Join(outputDir, fmt.Sprintf("isr_%s.s", v.Identifier))
 
-		if err = os.MkdirAll(filepath.Dir(outFile), 0750); err != nil {
+		if err = os.MkdirAll(filepath.Dir(outFile), os.ModePerm); err != nil {
 			log.Fatal("file io error: ", err)
 		}
 
@@ -135,7 +135,7 @@ func main() {
 	for _, v := range d.Variants {
 		outFile := filepath.Join(outputDir, fmt.Sprintf("linker_%s.ld", v.Identifier))
 
-		if err = os.MkdirAll(filepath.Dir(outFile), 0750); err != nil {
+		if err = os.MkdirAll(filepath.Dir(outFile), os.ModePerm); err != nil {
 			log.Fatal("file io error: ", err)
 		}
 

--- a/cmd/def-gen/main.go
+++ b/cmd/def-gen/main.go
@@ -109,7 +109,7 @@ func main() {
 
 	if len(output) > 0 {
 		// Create the directory to where the file will be stored.
-		err = os.MkdirAll(filepath.Dir(output), 0750)
+		err = os.MkdirAll(filepath.Dir(output), os.ModePerm)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(-4)

--- a/cmd/sigoc/root.go
+++ b/cmd/sigoc/root.go
@@ -61,7 +61,7 @@ var (
 			}
 
 			// Create the root directory.
-			if err := os.MkdirAll(rootDir, 0755); err != nil {
+			if err := os.MkdirAll(rootDir, os.ModePerm); err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v", err)
 				return
 			}

--- a/goir/include/Go-c/mlir/Dialects.h
+++ b/goir/include/Go-c/mlir/Dialects.h
@@ -22,7 +22,7 @@ extern "C"
 
   void mlirStringRefDestroy(MlirStringRef* ref);
 
-  intptr_t mlirTypeHash(MlirType type);
+  int mlirTypeHash(MlirType type);
 
   MlirAttribute mlirGoCreateTypeMetadata(MlirType type, MlirAttribute dict);
 
@@ -58,7 +58,7 @@ extern "C"
 
   MlirAttribute mlirGoCreateTypeMetadataDictionaryAttr(
     MlirContext context,
-    intptr_t nEntries,
+    int nEntries,
     MlirAttribute* entries);
 
   MlirBlock mlirRegionGetLastBlock(MlirRegion region);
@@ -73,11 +73,11 @@ extern "C"
   MlirOperation mlirValueGetDefiningOperation(MlirValue value);
 
   MlirBlock
-  mlirBlockCreate2(intptr_t nArgs, MlirType* args, intptr_t nLocations, MlirLocation* locations);
+  mlirBlockCreate2(int nArgs, MlirType* args, int nLocations, MlirLocation* locations);
 
   MlirAttribute mlirDistinctAttrGet(MlirAttribute attr);
 
-  void mlirGoBlockDumpTail(MlirBlock block, intptr_t count);
+  void mlirGoBlockDumpTail(MlirBlock block, int count);
 
   enum MlirGoAsmConstraintDirection
   {

--- a/goir/include/Go-c/mlir/Operations.h
+++ b/goir/include/Go-c/mlir/Operations.h
@@ -19,11 +19,11 @@ extern "C"
   MlirOperation mlirGoCreateInlineAssemblyOperation(
     MlirContext context,
     MlirAttribute asmStr,
-    intptr_t nConstraints,
+    int nConstraints,
     MlirAttribute* constraints,
-    intptr_t nRegisterClobbers,
+    int nRegisterClobbers,
     MlirAttribute* registerClobbers,
-    intptr_t nOperands,
+    int nOperands,
     MlirValue* operands,
     MlirLocation location);
 
@@ -292,7 +292,7 @@ extern "C"
     MlirContext context,
     MlirType resultType,
     MlirType elementType,
-    intptr_t numElements,
+    int numElements,
     bool isHeap,
     MlirLocation location);
 
@@ -340,9 +340,9 @@ extern "C"
     MlirContext context,
     MlirValue addr,
     MlirType baseType,
-    intptr_t nConstIndices,
+    int nConstIndices,
     int32_t* constIndices,
-    intptr_t nDynamicIndices,
+    int nDynamicIndices,
     MlirValue* dynamicIndices,
     MlirType type,
     MlirLocation location);
@@ -539,7 +539,7 @@ extern "C"
   MlirOperation mlirGoCreateTypeAssertOperation(
     MlirContext context,
     MlirValue value,
-    intptr_t nResults,
+    int nResults,
     MlirType* results,
     MlirLocation location);
 
@@ -608,7 +608,7 @@ extern "C"
   MlirOperation mlirGoCreateBranchOperation(
     MlirContext context,
     MlirBlock dest,
-    intptr_t nDestOperands,
+    int nDestOperands,
     MlirValue* destOperands,
     MlirLocation location);
 
@@ -616,16 +616,16 @@ extern "C"
     MlirContext context,
     MlirValue condition,
     MlirBlock trueDest,
-    intptr_t nTrueDestOperands,
+    int nTrueDestOperands,
     MlirValue* trueDestOperands,
     MlirBlock falseDest,
-    intptr_t nFalseDestOperands,
+    int nFalseDestOperands,
     MlirValue* falseDestOperands,
     MlirLocation location);
 
   MlirOperation mlirGoCreateReturnOperation(
     MlirContext context,
-    intptr_t nOperands,
+    int nOperands,
     MlirValue* operands,
     MlirLocation location);
 
@@ -636,18 +636,18 @@ extern "C"
   MlirOperation mlirGoCreateCallOperation(
     MlirContext context,
     MlirStringRef callee,
-    intptr_t nResultTypes,
+    int nResultTypes,
     MlirType* resultTypes,
-    intptr_t nOperands,
+    int nOperands,
     MlirValue* operands,
     MlirLocation location);
 
   MlirOperation mlirGoCreateCallIndirectOperation(
     MlirContext context,
     MlirValue callee,
-    intptr_t nResultTypes,
+    int nResultTypes,
     MlirType* resultTypes,
-    intptr_t nOperands,
+    int nOperands,
     MlirValue* operands,
     MlirLocation location);
 
@@ -655,7 +655,7 @@ extern "C"
     MlirContext context,
     MlirValue fn,
     MlirAttribute* method,
-    intptr_t nArgs,
+    int nArgs,
     MlirValue* args,
     MlirLocation location);
 
@@ -663,7 +663,7 @@ extern "C"
     MlirContext context,
     MlirValue fn,
     MlirStringRef method,
-    intptr_t nArgs,
+    int nArgs,
     MlirValue* args,
     MlirLocation location);
 
@@ -672,16 +672,16 @@ extern "C"
     MlirStringRef callee,
     MlirType signature,
     MlirValue value,
-    intptr_t nArgs,
+    int nArgs,
     MlirValue* args,
     MlirLocation location);
 
   MlirOperation mlirGoCreateBuiltInCallOperation(
     MlirContext context,
     MlirStringRef identifier,
-    intptr_t nResultTypes,
+    int nResultTypes,
     MlirType* resultTypes,
-    intptr_t nOperands,
+    int nOperands,
     MlirValue* operands,
     MlirLocation location);
 
@@ -737,7 +737,7 @@ extern "C"
 
   MlirOperation mlirGoCreateChanRecvOp(
     MlirContext context,
-    intptr_t nResultTypes,
+    int nResultTypes,
     MlirType* resultTypes,
     MlirValue channel,
     MlirLocation location);
@@ -760,11 +760,11 @@ extern "C"
     MlirContext context,
     bool hasDefault,
     MlirAttribute send,
-    intptr_t nChans,
+    int nChans,
     MlirValue* chans,
     MlirBlock defaultDest,
     MlirBlock exitDest,
-    intptr_t nCases,
+    int nCases,
     MlirBlock* cases,
     MlirLocation location);
 

--- a/goir/include/Go-c/mlir/Types.h
+++ b/goir/include/Go-c/mlir/Types.h
@@ -20,15 +20,15 @@ extern "C"
 
   bool mlirGoTypeIsAPointer(MlirType type);
 
-  MlirType mlirGoCreateArrayType(MlirType elementType, intptr_t length);
+  MlirType mlirGoCreateArrayType(MlirType elementType, int length);
 
   MlirType mlirGoCreateChanType(MlirType elementType, enum mlirGoChanDirection direction);
 
   MlirType mlirGoCreateInterfaceType(
     MlirContext context,
-    intptr_t nMethodNames,
+    int nMethodNames,
     MlirStringRef* methodNames,
-    intptr_t nMethods,
+    int nMethods,
     MlirType* methods);
 
   MlirType mlirGoCreateNamedInterfaceType(MlirContext context, MlirStringRef name);
@@ -36,9 +36,9 @@ extern "C"
   void mlirGoSetNamedInterfaceMethods(
     MlirContext context,
     MlirType interface,
-    intptr_t nMethodNames,
+    int nMethodNames,
     MlirStringRef* methodNames,
-    intptr_t nMethods,
+    int nMethods,
     MlirType* methods);
 
   MlirType mlirGoCreateMapType(MlirType keyType, MlirType valueType);
@@ -53,37 +53,37 @@ extern "C"
 
   MlirType mlirGoCreateStringType(MlirContext context);
 
-  MlirType mlirGoCreateBasicStructType(MlirContext context, intptr_t nFields, MlirType* fields);
+  MlirType mlirGoCreateBasicStructType(MlirContext context, int nFields, MlirType* fields);
 
   MlirType mlirGoCreateLiteralStructType(
     MlirContext context,
-    intptr_t nNames,
+    int nNames,
     MlirAttribute* names,
-    intptr_t nFields,
+    int nFields,
     MlirType* fields,
-    intptr_t nTags,
+    int nTags,
     MlirAttribute* tags);
 
   MlirType mlirGoCreateNamedStructType(MlirContext context, MlirStringRef name);
 
   void mlirGoSetStructTypeBody(
     MlirType type,
-    intptr_t nNames,
+    int nNames,
     MlirAttribute* names,
-    intptr_t nFields,
+    int nFields,
     MlirType* fields,
-    intptr_t nTags,
+    int nTags,
     MlirAttribute* tags);
 
   MlirType mlirGoCreateBooleanType(MlirContext ctx);
 
   bool mlirGoTypeIsBoolean(MlirType type);
 
-  MlirType mlirGoCreateSignedIntType(MlirContext ctx, intptr_t width);
+  MlirType mlirGoCreateSignedIntType(MlirContext ctx, int width);
 
   MlirType mlirGoStructTypeGetFieldType(MlirType type, int index);
 
-  MlirType mlirGoCreateUnsignedIntType(MlirContext ctx, intptr_t width);
+  MlirType mlirGoCreateUnsignedIntType(MlirContext ctx, int width);
 
   MlirType mlirGoCreateUintptrType(MlirContext ctx);
 
@@ -100,9 +100,9 @@ extern "C"
   MlirType mlirGoCreateFunctionType(
     MlirContext ctx,
     MlirType* receiver,
-    intptr_t nInputs,
+    int nInputs,
     MlirType* inputs,
-    intptr_t nResults,
+    int nResults,
     MlirType* results);
 
   bool mlirGoTypeIsAFunctionType(MlirType type);
@@ -111,13 +111,13 @@ extern "C"
 
   MlirType mlirGoFunctionTypeGetReceiver(MlirType type);
 
-  intptr_t mlirGoFunctionTypeGetNumInputs(MlirType type);
+  int mlirGoFunctionTypeGetNumInputs(MlirType type);
 
-  MlirType mlirGoFunctionTypeGetInput(MlirType type, intptr_t index);
+  MlirType mlirGoFunctionTypeGetInput(MlirType type, int index);
 
-  intptr_t mlirGoFunctionTypeGetNumResults(MlirType type);
+  int mlirGoFunctionTypeGetNumResults(MlirType type);
 
-  MlirType mlirGoFunctionTypeGetResult(MlirType type, intptr_t index);
+  MlirType mlirGoFunctionTypeGetResult(MlirType type, int index);
 
 #ifdef __cplusplus
 }

--- a/goir/lib/CAPI/mlir/Dialects.cxx
+++ b/goir/lib/CAPI/mlir/Dialects.cxx
@@ -142,7 +142,7 @@ void mlirStringRefDestroy(MlirStringRef* ref)
   free((void*)ref->data);
 }
 
-intptr_t mlirTypeHash(MlirType type)
+int mlirTypeHash(MlirType type)
 {
   auto _type = unwrap(type);
   return mlir::hash_value(_type);
@@ -358,7 +358,7 @@ MlirAttribute mlirGoCreateTypeMetadataEntryAttr(MlirType type, MlirAttribute dic
 
 MlirAttribute mlirGoCreateTypeMetadataDictionaryAttr(
   MlirContext context,
-  intptr_t nEntries,
+  int nEntries,
   MlirAttribute* entries)
 {
   const auto _context = unwrap(context);
@@ -419,7 +419,7 @@ MlirOperation mlirValueGetDefiningOperation(MlirValue value)
 }
 
 MlirBlock
-mlirBlockCreate2(intptr_t nArgs, MlirType* args, intptr_t nLocations, MlirLocation* locations)
+mlirBlockCreate2(int nArgs, MlirType* args, int nLocations, MlirLocation* locations)
 {
   assert(nArgs == nLocations);
   return mlirBlockCreate(nArgs, args, locations);
@@ -431,7 +431,7 @@ MlirAttribute mlirDistinctAttrGet(MlirAttribute attr)
   return wrap(mlir::DistinctAttr::create(_attr));
 }
 
-void mlirGoBlockDumpTail(MlirBlock block, intptr_t count)
+void mlirGoBlockDumpTail(MlirBlock block, int count)
 {
   auto _block = unwrap(block);
   auto it = _block->rbegin();

--- a/goir/lib/CAPI/mlir/Operations.cxx
+++ b/goir/lib/CAPI/mlir/Operations.cxx
@@ -18,11 +18,11 @@ using namespace mlir;
 MlirOperation mlirGoCreateInlineAssemblyOperation(
   MlirContext context,
   MlirAttribute asmStr,
-  intptr_t nConstraints,
+  int nConstraints,
   MlirAttribute* constraints,
-  intptr_t nRegisterClobbers,
+  int nRegisterClobbers,
   MlirAttribute* registerClobbers,
-  intptr_t nOperands,
+  int nOperands,
   MlirValue* operands,
   MlirLocation location)
 {
@@ -509,7 +509,7 @@ MlirOperation mlirGoCreateAllocaOperation(
   MlirContext context,
   MlirType resultType,
   MlirType elementType,
-  intptr_t numElements,
+  int numElements,
   bool isHeap,
   MlirLocation location)
 {
@@ -517,7 +517,7 @@ MlirOperation mlirGoCreateAllocaOperation(
   auto _resultType = unwrap(resultType);
   auto _elementType = unwrap(elementType);
   auto _location = unwrap(location);
-  intptr_t _numElements = 1;
+  int _numElements = 1;
   if (numElements > 0)
   {
     _numElements = numElements;
@@ -597,9 +597,9 @@ MlirOperation mlirGoCreateGepOperation(
   MlirContext context,
   MlirValue addr,
   MlirType baseType,
-  intptr_t nConstIndices,
+  int nConstIndices,
   int32_t* constIndices,
-  intptr_t nDynamicIndices,
+  int nDynamicIndices,
   MlirValue* dynamicIndices,
   MlirType type,
   MlirLocation location)
@@ -1159,7 +1159,7 @@ MlirOperation mlirGoCreateChangeInterfaceOperation(
 MlirOperation mlirGoCreateTypeAssertOperation(
   MlirContext context,
   MlirValue value,
-  intptr_t nResults,
+  int nResults,
   MlirType* results,
   MlirLocation location)
 {
@@ -1309,7 +1309,7 @@ MlirOperation mlirGoCreateAtomicSwapOperation(
 MlirOperation mlirGoCreateBranchOperation(
   MlirContext context,
   MlirBlock dest,
-  intptr_t nDestOperands,
+  int nDestOperands,
   MlirValue* destOperands,
   MlirLocation location)
 {
@@ -1329,10 +1329,10 @@ MlirOperation mlirGoCreateCondBranchOperation(
   MlirContext context,
   MlirValue condition,
   MlirBlock trueDest,
-  intptr_t nTrueDestOperands,
+  int nTrueDestOperands,
   MlirValue* trueDestOperands,
   MlirBlock falseDest,
-  intptr_t nFalseDestOperands,
+  int nFalseDestOperands,
   MlirValue* falseDestOperands,
   MlirLocation location)
 {
@@ -1360,7 +1360,7 @@ MlirOperation mlirGoCreateCondBranchOperation(
 
 MlirOperation mlirGoCreateReturnOperation(
   MlirContext context,
-  intptr_t nOperands,
+  int nOperands,
   MlirValue* operands,
   MlirLocation location)
 {
@@ -1382,9 +1382,9 @@ MlirOperation mlirGoCreateReturnOperation(
 MlirOperation mlirGoCreateCallOperation(
   MlirContext context,
   MlirStringRef callee,
-  intptr_t nResultTypes,
+  int nResultTypes,
   MlirType* resultTypes,
-  intptr_t nOperands,
+  int nOperands,
   MlirValue* operands,
   MlirLocation location)
 {
@@ -1407,9 +1407,9 @@ MlirOperation mlirGoCreateCallOperation(
 MlirOperation mlirGoCreateCallIndirectOperation(
   MlirContext context,
   MlirValue callee,
-  intptr_t nResultTypes,
+  int nResultTypes,
   MlirType* resultTypes,
-  intptr_t nOperands,
+  int nOperands,
   MlirValue* operands,
   MlirLocation location)
 {
@@ -1433,7 +1433,7 @@ MlirOperation mlirGoCreateDeferOperation(
   MlirContext context,
   MlirValue fn,
   MlirAttribute* method,
-  intptr_t nArgs,
+  int nArgs,
   MlirValue* args,
   MlirLocation location)
 {
@@ -1458,7 +1458,7 @@ MlirOperation mlirGoCreateGoOperation(
   MlirContext context,
   MlirValue fn,
   MlirStringRef method,
-  intptr_t nArgs,
+  int nArgs,
   MlirValue* args,
   MlirLocation location)
 {
@@ -1487,7 +1487,7 @@ MlirOperation mlirGoCreateInterfaceCall(
   MlirStringRef callee,
   MlirType signature,
   MlirValue ifaceValue,
-  intptr_t nArgs,
+  int nArgs,
   MlirValue* args,
   MlirLocation location)
 {
@@ -1509,9 +1509,9 @@ MlirOperation mlirGoCreateInterfaceCall(
 MlirOperation mlirGoCreateBuiltInCallOperation(
   MlirContext context,
   MlirStringRef identifier,
-  intptr_t nResultTypes,
+  int nResultTypes,
   MlirType* resultTypes,
-  intptr_t nOperands,
+  int nOperands,
   MlirValue* operands,
   MlirLocation location)
 {
@@ -1662,7 +1662,7 @@ MlirOperation mlirGoCreateMakeInterfaceOperation(
 
 MlirOperation mlirGoCreateChanRecvOp(
   MlirContext context,
-  intptr_t nResultTypes,
+  int nResultTypes,
   MlirType* resultTypes,
   MlirValue channel,
   MlirLocation location)
@@ -1718,11 +1718,11 @@ MlirOperation mlirGoCreateChanSelectOp(
   MlirContext context,
   bool hasDefault,
   MlirAttribute send,
-  intptr_t nChans,
+  int nChans,
   MlirValue* chans,
   MlirBlock defaultDest,
   MlirBlock exitDest,
-  intptr_t nCases,
+  int nCases,
   MlirBlock* cases,
   MlirLocation location)
 {

--- a/goir/lib/CAPI/mlir/Types.cxx
+++ b/goir/lib/CAPI/mlir/Types.cxx
@@ -40,7 +40,7 @@ bool mlirGoTypeIsAPointer(MlirType type)
   return mlir::go::isa<mlir::go::PointerType>(_type);
 }
 
-MlirType mlirGoCreateArrayType(MlirType elementType, intptr_t length)
+MlirType mlirGoCreateArrayType(MlirType elementType, int length)
 {
   auto _elementType = unwrap(elementType);
   return wrap(mlir::go::ArrayType::get(_elementType.getContext(), _elementType, length));
@@ -69,9 +69,9 @@ MlirType mlirGoCreateChanType(MlirType elementType, enum mlirGoChanDirection dir
 
 MlirType mlirGoCreateInterfaceType(
   MlirContext context,
-  intptr_t nMethodNames,
+  int nMethodNames,
   MlirStringRef* methodNames,
-  intptr_t nMethods,
+  int nMethods,
   MlirType* methods)
 {
   auto _context = unwrap(context);
@@ -93,7 +93,7 @@ MlirType mlirGoCreateInterfaceType(
 
   // Populate the method map
   mlir::go::detail::InterfaceTypeStorage::FunctionMap _methodsMap;
-  for (intptr_t i = 0; i < nMethodNames; i++)
+  for (int i = 0; i < nMethodNames; i++)
   {
     _methodsMap[_methodNames[i].str()] = mlir::cast<mlir::go::FunctionType>(_methods[i]);
   }
@@ -114,9 +114,9 @@ MlirType mlirGoCreateNamedInterfaceType(MlirContext context, MlirStringRef name)
 void mlirGoSetNamedInterfaceMethods(
   MlirContext context,
   MlirType interface,
-  intptr_t nMethodNames,
+  int nMethodNames,
   MlirStringRef* methodNames,
-  intptr_t nMethods,
+  int nMethods,
   MlirType* methods)
 {
   auto _interface = mlir::cast<mlir::go::InterfaceType>(unwrap(interface));
@@ -138,7 +138,7 @@ void mlirGoSetNamedInterfaceMethods(
 
   // Populate the method map
   mlir::go::detail::InterfaceTypeStorage::FunctionMap _methodsMap;
-  for (intptr_t i = 0; i < nMethodNames; i++)
+  for (int i = 0; i < nMethodNames; i++)
   {
     _methodsMap[_methodNames[i].str()] = mlir::cast<mlir::go::FunctionType>(_methods[i]);
   }
@@ -190,7 +190,7 @@ MlirType mlirGoCreateStringType(MlirContext context)
   return wrap(::mlir::go::StringType::get(unwrap(context)));
 }
 
-MlirType mlirGoCreateBasicStructType(MlirContext context, intptr_t nFields, MlirType* fields)
+MlirType mlirGoCreateBasicStructType(MlirContext context, int nFields, MlirType* fields)
 {
   auto _context = unwrap(context);
 
@@ -202,11 +202,11 @@ MlirType mlirGoCreateBasicStructType(MlirContext context, intptr_t nFields, Mlir
 
 MlirType mlirGoCreateLiteralStructType(
   MlirContext context,
-  intptr_t nNames,
+  int nNames,
   MlirAttribute* names,
-  intptr_t nFields,
+  int nFields,
   MlirType* fields,
-  intptr_t nTags,
+  int nTags,
   MlirAttribute* tags)
 {
   auto _context = unwrap(context);
@@ -255,7 +255,7 @@ MlirType mlirGoCreateLiteralStructType(
 
   mlir::SmallVector<mlir::go::GoStructType::FieldTy> _fields;
   _fields.reserve(nFields);
-  for (intptr_t i = 0; i < nFields; i++)
+  for (int i = 0; i < nFields; i++)
   {
     _fields.emplace_back(_fieldNames[i], _fieldTypes[i], _fieldTags[i]);
   }
@@ -272,11 +272,11 @@ MlirType mlirGoCreateNamedStructType(MlirContext context, MlirStringRef name)
 
 void mlirGoSetStructTypeBody(
   MlirType type,
-  intptr_t nNames,
+  int nNames,
   MlirAttribute* names,
-  intptr_t nFields,
+  int nFields,
   MlirType* fields,
-  intptr_t nTags,
+  int nTags,
   MlirAttribute* tags)
 {
   std::vector<mlir::Type> body;
@@ -326,7 +326,7 @@ void mlirGoSetStructTypeBody(
 
   mlir::SmallVector<mlir::go::GoStructType::FieldTy> _fields;
   _fieldNames.reserve(nFields);
-  for (intptr_t i = 0; i < nFields; i++)
+  for (int i = 0; i < nFields; i++)
   {
     _fields.emplace_back(_fieldNames[i], _fieldTypes[i], _fieldTags[i]);
   }
@@ -351,7 +351,7 @@ bool mlirGoTypeIsBoolean(MlirType type)
   return mlir::go::isa<mlir::go::BooleanType>(unwrap(type));
 }
 
-MlirType mlirGoCreateSignedIntType(MlirContext ctx, intptr_t width)
+MlirType mlirGoCreateSignedIntType(MlirContext ctx, int width)
 {
   auto _ctx = unwrap(ctx);
   if (width > 0)
@@ -361,7 +361,7 @@ MlirType mlirGoCreateSignedIntType(MlirContext ctx, intptr_t width)
   return wrap(mlir::go::IntegerType::get(_ctx, mlir::go::IntegerType::Signed));
 }
 
-MlirType mlirGoCreateUnsignedIntType(MlirContext ctx, intptr_t width)
+MlirType mlirGoCreateUnsignedIntType(MlirContext ctx, int width)
 {
   auto _ctx = unwrap(ctx);
   if (width > 0)
@@ -419,9 +419,9 @@ int mlirGoIntegerTypeGetWidth(MlirType type)
 MlirType mlirGoCreateFunctionType(
   MlirContext ctx,
   MlirType* receiver,
-  intptr_t nInputs,
+  int nInputs,
   MlirType* inputs,
-  intptr_t nResults,
+  int nResults,
   MlirType* results)
 {
   auto _ctx = unwrap(ctx);
@@ -461,25 +461,25 @@ MlirType mlirGoFunctionTypeGetReceiver(MlirType type)
   return wrap(_type.getReceiver());
 }
 
-intptr_t mlirGoFunctionTypeGetNumInputs(MlirType type)
+int mlirGoFunctionTypeGetNumInputs(MlirType type)
 {
   const auto _type = mlir::go::cast<mlir::go::FunctionType>(unwrap(type));
   return _type.getNumInputs();
 }
 
-MlirType mlirGoFunctionTypeGetInput(MlirType type, intptr_t index)
+MlirType mlirGoFunctionTypeGetInput(MlirType type, int index)
 {
   const auto _type = mlir::go::cast<mlir::go::FunctionType>(unwrap(type));
   return wrap(_type.getInput(index));
 }
 
-intptr_t mlirGoFunctionTypeGetNumResults(MlirType type)
+int mlirGoFunctionTypeGetNumResults(MlirType type)
 {
   const auto _type = mlir::go::cast<mlir::go::FunctionType>(unwrap(type));
   return _type.getNumResults();
 }
 
-MlirType mlirGoFunctionTypeGetResult(MlirType type, intptr_t index)
+MlirType mlirGoFunctionTypeGetResult(MlirType type, int index)
 {
   const auto _type = mlir::go::cast<mlir::go::FunctionType>(unwrap(type));
   return wrap(_type.getResult(index));

--- a/link.rsp
+++ b/link.rsp
@@ -210,7 +210,3 @@
 -lMLIRVectorTransforms
 -lMLIRVectorUtils
 -lMLIRViewLikeInterface
--lMLIRX86VectorDialect
--lMLIRX86VectorToLLVMIRTranslation
--lMLIRX86VectorTransforms
-

--- a/mlir/mlir.i
+++ b/mlir/mlir.i
@@ -1,5 +1,7 @@
 %module mlir
 
+// NOTE: This a workaround since SWIG does not actually support the __attribute__ syntax on Linux. On Windows, this
+//       actually has no effect when building static.
 #define _WIN32
 
 // Remove Mlir prefix from functions and types
@@ -7,9 +9,10 @@
 
 %header %{
 #include <stdbool.h>
+#include <stdint.h>
 //#include "mlir-c/Dialect/Async.h"
 //#include "mlir-c/Dialect/ControlFlow.h"
-#include "mlir-c/Dialect/Func.h"
+//#include "mlir-c/Dialect/Func.h"
 //#include "mlir-c/Dialect/GPU.h" 
 //#include "mlir-c/Dialect/Linalg.h"
 #include "mlir-c/Dialect/LLVM.h"
@@ -34,7 +37,7 @@
 //#include "mlir-c/IntegerSet.h"
 //#include "mlir-c/Interfaces.h"
 #include "mlir-c/IR.h"
-#include "mlir-c/Pass.h"
+//#include "mlir-c/Pass.h"
 //#include "mlir-c/RegisterEverything.h"
 //#include "mlir-c/Transforms.h"
 
@@ -84,6 +87,9 @@
 #include "Go-c/mlir/Types.h"
 %}
 
+%typemap(gotype) intptr_t "int"
+%typemap(gotype) uintptr_t "uint"
+
 %include inttypes.i
 %include typemaps.i
 
@@ -91,10 +97,10 @@
 %ignore mlirStringRefCreateFromCString;
 %ignore mlirStringRefEqual;
 
-%define MLIR_STRING_SLICE_TYPEMAP(N_PARAM, ARR_PARAM)
-%typemap(gotype) (intptr_t N_PARAM, MlirStringRef *ARR_PARAM) "[]string";
-%typemap(imtype) (intptr_t N_PARAM, MlirStringRef *ARR_PARAM) "[]C.MlirStringRef";
-%typemap(goin) (intptr_t N_PARAM, MlirStringRef *ARR_PARAM) %{
+%define _MLIR_STRING_SLICE_TYPEMAP(N_TYPE, N_PARAM, ARR_PARAM)
+%typemap(gotype) (N_TYPE N_PARAM, MlirStringRef *ARR_PARAM) "[]string";
+%typemap(imtype) (N_TYPE N_PARAM, MlirStringRef *ARR_PARAM) "[]C.MlirStringRef";
+%typemap(goin) (N_TYPE N_PARAM, MlirStringRef *ARR_PARAM) %{
     $result = make([]C.MlirStringRef, 0, len($input))
     for _, val := range $input {
         strVal := C.mlirStringRefCreateFromCString(C.CString(val))
@@ -102,10 +108,35 @@
     }
 %}
 
-%typemap(in) (intptr_t N_PARAM, MlirStringRef *ARR_PARAM) %{
+%typemap(in) (N_TYPE N_PARAM, MlirStringRef *ARR_PARAM) %{
     $1 = ($1_type)$input.len;
     $2 = (MlirStringRef*)$input.array;
 %}
+%enddef
+
+%define MLIR_STRING_SLICE_TYPEMAP(N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(short, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(unsigned short, N_PARAM, ARR_PARAM)
+
+_MLIR_STRING_SLICE_TYPEMAP(int, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(unsigned int, N_PARAM, ARR_PARAM)
+
+_MLIR_STRING_SLICE_TYPEMAP(long, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(unsigned long, N_PARAM, ARR_PARAM)
+
+_MLIR_STRING_SLICE_TYPEMAP(long long, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(unsigned long long, N_PARAM, ARR_PARAM)
+
+_MLIR_STRING_SLICE_TYPEMAP(int8_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(uint8_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(int16_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(uint16_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(int32_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(uint32_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(int64_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(uint64_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(intptr_t, N_PARAM, ARR_PARAM)
+_MLIR_STRING_SLICE_TYPEMAP(uintptr_t, N_PARAM, ARR_PARAM)
 %enddef
 
 MLIR_STRING_SLICE_TYPEMAP(nMethodNames, methodNames)
@@ -125,10 +156,10 @@ MLIR_STRING_SLICE_TYPEMAP(nMethodNames, methodNames)
     $result = $1;
 %}
 
-%define MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, N_PARAM, ARR_PARAM)
-%typemap(gotype) (intptr_t N_PARAM, TYPE *ARR_PARAM) "[]GOTYPE";
-%typemap(imtype) (intptr_t N_PARAM, TYPE *ARR_PARAM) "[]C.TYPE";
-%typemap(goin) (intptr_t N_PARAM, TYPE *ARR_PARAM) %{
+%define _MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, N_TYPE, N_PARAM, ARR_PARAM)
+%typemap(gotype) (N_TYPE N_PARAM, TYPE *ARR_PARAM) "[]GOTYPE";
+%typemap(imtype) (N_TYPE N_PARAM, TYPE *ARR_PARAM) "[]C.TYPE";
+%typemap(goin) (N_TYPE N_PARAM, TYPE *ARR_PARAM) %{
    $result = make([]C.TYPE, 0, len($input))
    for _, val := range $input {
         if val != nil {
@@ -139,14 +170,14 @@ MLIR_STRING_SLICE_TYPEMAP(nMethodNames, methodNames)
    }
 %}
 
-%typemap(in) (intptr_t N_PARAM, TYPE *ARR_PARAM) %{
+%typemap(in) (N_TYPE N_PARAM, TYPE *ARR_PARAM) %{
     $1 = ($1_type)$input.len;
     $2 = (TYPE*)$input.array;
 %}
 
-%typemap(gotype) (intptr_t N_PARAM, TYPE const *ARR_PARAM) "[]GOTYPE";
-%typemap(imtype) (intptr_t N_PARAM, TYPE const *ARR_PARAM) "[]C.TYPE";
-%typemap(goin) (intptr_t N_PARAM, TYPE const *ARR_PARAM) %{
+%typemap(gotype) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) "[]GOTYPE";
+%typemap(imtype) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) "[]C.TYPE";
+%typemap(goin) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) %{
     $result = make([]C.TYPE, 0, len($input))
     for _, val := range $input {
         if val != nil {
@@ -157,10 +188,35 @@ MLIR_STRING_SLICE_TYPEMAP(nMethodNames, methodNames)
     }
 %}
 
-%typemap(in) (intptr_t N_PARAM, TYPE const *ARR_PARAM) %{
+%typemap(in) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) %{
     $1 = ($1_type)$input.len;
     $2 = (TYPE*)$input.array;
 %}
+%enddef
+
+%define MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, short, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned short, N_PARAM, ARR_PARAM)
+
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, int, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned int, N_PARAM, ARR_PARAM)
+
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, long, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned long, N_PARAM, ARR_PARAM)
+
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, long long, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned long long, N_PARAM, ARR_PARAM)
+
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, int8_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, uint8_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, int16_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, uint16_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, int32_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, uint32_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, int64_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, uint64_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, intptr_t, N_PARAM, ARR_PARAM)
+_MLIR_SLICE_TYPEMAP(TYPE, GOTYPE, uintptr_t, N_PARAM, ARR_PARAM)
 %enddef
 
 MLIR_SLICE_TYPEMAP(MlirAffineExpr, AffineExpr, nAffineExprs, affineExprs)
@@ -212,36 +268,61 @@ MLIR_SLICE_TYPEMAP(MlirValue, Value, nValues, values)
 MLIR_SLICE_TYPEMAP(MlirValue, Value, nArgs, args)
 MLIR_SLICE_TYPEMAP(MlirValue, Value, nChans, chans)
 
-%define MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, N_PARAM, ARR_PARAM)
-%typemap(gotype) (intptr_t N_PARAM, TYPE *ARR_PARAM) "[]GOTYPE";
-%typemap(gotype) (intptr_t N_PARAM, TYPE *ARR_PARAM) "[]GOTYPE";
-%typemap(imtype) (intptr_t N_PARAM, TYPE *ARR_PARAM) "[]C.TYPE";
-%typemap(goin) (intptr_t N_PARAM, TYPE *ARR_PARAM) %{
+%define _MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, N_TYPE, N_PARAM, ARR_PARAM)
+%typemap(gotype) (N_TYPE N_PARAM, TYPE *ARR_PARAM) "[]GOTYPE";
+%typemap(gotype) (N_TYPE N_PARAM, TYPE *ARR_PARAM) "[]GOTYPE";
+%typemap(imtype) (N_TYPE N_PARAM, TYPE *ARR_PARAM) "[]C.TYPE";
+%typemap(goin) (N_TYPE N_PARAM, TYPE *ARR_PARAM) %{
     $result = make([]C.TYPE, 0, len($input))
     for _, val := range $input {
         $result = append($result, C.TYPE(val))
     }
 %}
 
-%typemap(in) (intptr_t N_PARAM, TYPE *ARR_PARAM) %{
+%typemap(in) (N_TYPE N_PARAM, TYPE *ARR_PARAM) %{
     $1 = ($1_type)$input.len;
     $2 = (TYPE*)$input.array;
 %}
 
-%typemap(gotype) (intptr_t N_PARAM, TYPE const *ARR_PARAM) "[]GOTYPE";
-%typemap(imtype) (intptr_t N_PARAM, TYPE const *ARR_PARAM) "[]C.TYPE";
-%typemap(in) (intptr_t N_PARAM, TYPE const *ARR_PARAM) "[]C.TYPE";
-%typemap(goin) (intptr_t N_PARAM, TYPE const *ARR_PARAM) %{
+%typemap(gotype) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) "[]GOTYPE";
+%typemap(imtype) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) "[]C.TYPE";
+%typemap(in) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) "[]C.TYPE";
+%typemap(goin) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) %{
    $result = make([]C.TYPE, 0, len($input))
    for _, val := range $input {
        $result = append($result, C.TYPE(val))
    }
 %}
 
-%typemap(in) (intptr_t N_PARAM, TYPE const *ARR_PARAM) %{
+%typemap(in) (N_TYPE N_PARAM, TYPE const *ARR_PARAM) %{
     $1 = ($1_type)$input.len;
     $2 = (TYPE*)$input.array;
 %}
+%enddef
+
+%define MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, short, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned short, N_PARAM, ARR_PARAM)
+
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, int, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned int, N_PARAM, ARR_PARAM)
+
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, long, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned long, N_PARAM, ARR_PARAM)
+
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, long long, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, unsigned long long, N_PARAM, ARR_PARAM)
+
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, int8_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, uint8_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, int16_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, uint16_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, int32_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, uint32_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, int64_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, uint64_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, intptr_t, N_PARAM, ARR_PARAM)
+_MLIR_PRIMITIVE_SLICE_TYPEMAP(TYPE, GOTYPE, uintptr_t, N_PARAM, ARR_PARAM)
 %enddef
 
 MLIR_PRIMITIVE_SLICE_TYPEMAP(bool, bool, size, values)
@@ -313,13 +394,13 @@ LLVM_TYPEMAP(LLVMErrorRef)
 //%include "mlir-c/IntegerSet.h"
 //%include "mlir-c/Interfaces.h"
 %include "mlir-c/IR.h"
-%include "mlir-c/Pass.h"
+//%include "mlir-c/Pass.h"
 //%include "mlir-c/RegisterEverything.h"
 //%include "mlir-c/Transforms.h"
 
 //%include "mlir-c/Dialect/Async.h"
 //%include "mlir-c/Dialect/ControlFlow.h"
-%include "mlir-c/Dialect/Func.h"
+//%include "mlir-c/Dialect/Func.h"
 //%include "mlir-c/Dialect/GPU.h"
 //%include "mlir-c/Dialect/Linalg.h"
 %include "mlir-c/Dialect/LLVM.h"

--- a/src/index.yaml
+++ b/src/index.yaml
@@ -3,6 +3,13 @@ include:
   - builtin
   - internal/buildcfg
   - internal/bytealg
+  - internal/goarch
+  - internal/godebug
+  - internal/goexperiment
+  - internal/goos
+  - internal/goroot
+  - internal/gover
+  - internal/goversion
   - io
   - unicode
   - unicode/utf8

--- a/src/runtime/arm/cortexm/fpu.go
+++ b/src/runtime/arm/cortexm/fpu.go
@@ -4,7 +4,7 @@ package cortexm
 
 import (
 	"runtime/arm/cortexm/support/fpu"
-	"runtime/arm/cortexm/support/systemcontrol"
+	"runtime/arm/cortexm/support/systemControl"
 )
 
 type extendedFrame struct {

--- a/src/runtime/arm/cortexm/timing.go
+++ b/src/runtime/arm/cortexm/timing.go
@@ -3,7 +3,7 @@ package cortexm
 import (
 	"sync/atomic"
 
-	"runtime/arm/cortexm/support/systemcontrol"
+	"runtime/arm/cortexm/support/systemControl"
 	"runtime/arm/cortexm/support/systick"
 )
 


### PR DESCRIPTION
builder:
Fix file and directory permissions.
Add floating-point settings to assembler options.

cmd/csp-gen:
Fix file and directory permissions.

cmd/def-gen:
Fix file and directory permissions.

cmd/sigoc:
Fix file and directory permissions.

goir:
Replace usages of intptr_t with int in C API to better translate to Go when generating the CGo API using SWIG.

sigo runtime:
Fixed case errors in imports.

other:
Improvements to LLVM and MLIR SWIG interface files. Removed X86 dialect libraries from link.rsp that are NOT available in the normal Linux build of MLIR by default. Updated README.