### PR TITLE
Bugfix/fix build toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifeq ($(OS),Windows_NT)
 	CXX ?= clang++
 	# NOTE: ld should be replaced with ld.lld directly on Windows since Go is dumb.
 else
-	CGO_LDFLAGS += -fuse-ld=lld -lrt -ldl -lpthread -lm -lz -ltinfo
+	CGO_LDFLAGS += -fuse-ld=lld -lrt -ldl -lpthread -lm -lz -ltinfo -lzstd
 endif
 
 CMAKE_COMPILER_ARGS := -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX}
@@ -102,6 +102,7 @@ DEBUG ?= 0
 
 define build-compiler-rt
 	CC=${CC} CXX=${CXX} cmake $(ROOT_DIR)/thirdparty/llvm-project/compiler-rt -G "Ninja" -B ./build/Release/compiler-rt-$(1)-$(2) \
+		-DCMAKE_TOOLCHAIN_FILE=$(ROOT_DIR)/cmake/compiler-rt-toolchain.cmake \
 		-DCMAKE_INSTALL_PREFIX=$(ROOT_DIR)/lib/compiler-rt/$(1)/$(2) \
 		${CMAKE_COMPILER_ARGS} \
 		-DCMAKE_BUILD_TYPE=Release \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Others coming soon...
 3. SWIG (https://www.swig.org/)
 
 ```shell
-sudo apt install clang swig
+sudo apt install clang swig libzstd-dev
 ```
 
 Run the following commands to create a debug build:

--- a/builder/toolchain.go
+++ b/builder/toolchain.go
@@ -1,8 +1,11 @@
 package builder
 
 import (
-	"os/exec"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 type Toolchain struct {
@@ -15,9 +18,9 @@ func findToolchain(env Env) (Toolchain, error) {
 	cc := env.Value("CC")
 	if len(cc) == 0 {
 		var err error
-		if cc, err = findExecutable("clang"); err != nil {
+		if cc, err = findVersionedExecutable("clang", "-"); err != nil {
 			// Fallback to GCC.
-			cc, err = findExecutable("gcc")
+			cc, err = findVersionedExecutable("gcc", "-")
 		}
 
 		if err != nil {
@@ -28,9 +31,9 @@ func findToolchain(env Env) (Toolchain, error) {
 	ld := env.Value("LD")
 	if len(ld) == 0 {
 		var err error
-		if ld, err = findExecutable("ld.lld"); err != nil {
+		if ld, err = findVersionedExecutable("ld.lld", "-"); err != nil {
 			// Fallback to LD.
-			ld, err = findExecutable("ld")
+			ld, err = findVersionedExecutable("ld", "-")
 		}
 
 		if err != nil {
@@ -41,9 +44,9 @@ func findToolchain(env Env) (Toolchain, error) {
 	objcopy := env.Value("OBJCOPY")
 	if len(objcopy) == 0 {
 		var err error
-		if objcopy, err = findExecutable("llvm-objcopy"); err != nil {
+		if objcopy, err = findVersionedExecutable("llvm-objcopy", "-"); err != nil {
 			// Fallback to objcopy.
-			objcopy, err = findExecutable("objcopy")
+			objcopy, err = findVersionedExecutable("objcopy", "-")
 		}
 
 		if err != nil {
@@ -58,10 +61,33 @@ func findToolchain(env Env) (Toolchain, error) {
 	}, nil
 }
 
-func findExecutable(cmd string) (string, error) {
-	fname, err := exec.LookPath(cmd)
-	if err == nil {
-		fname, err = filepath.Abs(fname)
+func findVersionedExecutable(cmd string, sep string) (string, error) {
+	pathEnv := os.Getenv("PATH")
+	paths := strings.Split(pathEnv, string(os.PathListSeparator))
+
+	var exe string
+	for _, pathPrefix := range paths {
+		wildcard := filepath.Join(pathPrefix, cmd) + sep + "*"
+		if versions, err := filepath.Glob(wildcard); err == nil {
+			maxVersion := 0
+			for _, version := range versions {
+				s := strings.Split(version, cmd+sep)
+				if len(s) > 1 {
+					if v, err := strconv.Atoi(s[1]); err == nil && v > maxVersion {
+						maxVersion = v
+						exe = version
+					}
+				} else {
+					// Just use this version directly.
+					exe = version
+				}
+			}
+		}
 	}
-	return fname, err
+
+	if len(exe) != 0 {
+		return exe, nil
+	}
+
+	return "", fmt.Errorf("could not find executable for %s", cmd)
 }

--- a/cmake/compiler-rt-toolchain.cmake
+++ b/cmake/compiler-rt-toolchain.cmake
@@ -1,0 +1,3 @@
+# Bypass "ADD_LIBRARY called with SHARED option" error on some systems with an older CMake version.
+set(CMAKE_SYSTEM_NAME Linux)
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE CACHE)


### PR DESCRIPTION
Added bypass for a CMake error that occurs when compiling the `compiler-rt` libraries.

Implemented better toolchain detection in the builder to handle systems that have multiple versions of a build toolchain installed at once. It will lookup the command by prefix and then select to highest version unless the tool is specified explicitly in the process environment.