### PR TITLE
Added `CriticalSection` API to the `sync` package.

### DIFF
--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -90,7 +90,7 @@ func channelReceive(c _channel, block bool) (unsafe.Pointer, bool) {
 	if c.state == nil {
 		// Block indefinitely.
 		for {
-			schedulerPause()
+			gosched()
 		}
 	}
 
@@ -104,7 +104,7 @@ func _channelReceive(c _channel, block bool) (unsafe.Pointer, bool) {
 	if c.state == nil {
 		// Block indefinitely.
 		for {
-			schedulerPause()
+			gosched()
 		}
 	}
 
@@ -160,7 +160,7 @@ func channelRange(c _channel) (unsafe.Pointer, bool) {
 	if c.state == nil {
 		// Block indefinitely.
 		for {
-			schedulerPause()
+			gosched()
 		}
 	}
 
@@ -209,7 +209,7 @@ func channelSelect(chanArr *_channel, sendArr *bool, readyArr *int, count int, h
 		}
 
 		// If no cases are ready and there's no default case, yield to another goroutine.
-		schedulerPause()
+		gosched()
 	}
 
 	return -1

--- a/src/runtime/gc.go
+++ b/src/runtime/gc.go
@@ -109,9 +109,7 @@ func (gc *_gc) markRoots() {
 	for i := 0; i < gcMaxIterations && gc.currentAddress < gc.endAddress; i++ {
 		ptr := *(*unsafe.Pointer)(unsafe.Pointer(gc.currentAddress))
 		if obj := gc.findObject(uintptr(ptr)); obj != nil {
-			state := DisableInterrupts()
 			obj.color = gcGray
-			EnableInterrupts(state)
 		}
 		gc.currentAddress += gcWordSize
 	}
@@ -124,9 +122,7 @@ func (gc *_gc) markRoots() {
 func (gc *_gc) markGrayObjects() {
 	for i := 0; i < gcMaxIterations && gc.toScan != nil; i++ {
 		if gc.toScan.color == gcGray {
-			state := DisableInterrupts()
 			gc.toScan.color = gcBlack
-			EnableInterrupts(state)
 			gc.scanObject(gc.toScan)
 		}
 		gc.toScan = gc.toScan.next
@@ -167,6 +163,7 @@ func (gc *_gc) sweep() {
 	if gc.toScan == nil {
 		gc.phase = gcIdle
 	}
+
 	EnableInterrupts(state)
 }
 
@@ -190,9 +187,7 @@ func (gc *_gc) scanObject(obj *gcObject) {
 		childPtr := *(*unsafe.Pointer)(unsafe.Pointer(ptr))
 		if child := gc.findObject(uintptr(childPtr)); child != nil {
 			if child.color == gcWhite {
-				state := DisableInterrupts()
 				child.color = gcGray
-				EnableInterrupts(state)
 			}
 		}
 	}
@@ -244,8 +239,8 @@ func initgc() {
 
 //go:export alloc runtime.alloc
 func alloc(size uintptr) unsafe.Pointer {
-	gc.mutex.Lock()
-	state := DisableInterrupts()
+	criticalSection := sync.NewCriticalSection(&gc.mutex)
+	criticalSection.Begin()
 
 	allocSize := gcObjectSize + size
 
@@ -255,7 +250,6 @@ func alloc(size uintptr) unsafe.Pointer {
 		gc.fullGC()
 		ptr = malloc(allocSize)
 		if ptr == nil {
-			gc.mutex.Unlock()
 			abort()
 		}
 	}
@@ -272,8 +266,7 @@ func alloc(size uintptr) unsafe.Pointer {
 		gc.startMark()
 	}
 
-	gc.mutex.Unlock()
-	EnableInterrupts(state)
+	criticalSection.End()
 	return unsafe.Add(ptr, gcObjectSize)
 }
 
@@ -283,7 +276,7 @@ func gcmain() {
 		gc.mutex.Lock()
 		gc.iterate()
 		gc.mutex.Unlock()
-		schedulerPause()
+		gosched()
 	}
 }
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1,5 +1,5 @@
 package runtime
 
 func Gosched() {
-	schedulerPause()
+	gosched()
 }

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -34,11 +34,11 @@ type goroutine struct {
 //sigo:extern goroutineStackSize runtime._goroutineStackSize
 //sigo:extern initGoroutine runtime.initGoroutine
 //sigo:extern alignStack runtime.alignStack
-//sigo:extern schedulerPause runtime.schedulerPause
+//sigo:extern gosched runtime.gosched
 
 //go:export lastGoroutine runtime.lastGoroutine
 //go:export currentGoroutine runtime.currentGoroutine
-//go:export runScheduler runtime.runScheduler
+//go:export schedule runtime.schedule
 //go:export addGoroutine runtime.addGoroutine
 //go:export removeGoroutine runtime.removeGoroutine
 //go:export sleep runtime.sleep
@@ -58,9 +58,9 @@ var (
 
 func initGoroutine(unsafe.Pointer)
 func alignStack(n uintptr) uintptr
-func schedulerPause()
+func gosched()
 
-func runScheduler() bool {
+func schedule() bool {
 	state := DisableInterrupts()
 
 	// Check for stack overflow on current goroutine.
@@ -214,7 +214,7 @@ func gopark(ptr unsafe.Pointer) {
 	g.state = goroutineParked
 	EnableInterrupts(state)
 	for g.state == goroutineParked {
-		schedulerPause()
+		gosched()
 	}
 }
 
@@ -226,7 +226,7 @@ func goresume(ptr unsafe.Pointer) {
 		EnableInterrupts(state)
 
 		targetGoroutine = g
-		schedulerPause()
+		gosched()
 		return
 	}
 	EnableInterrupts(state)

--- a/src/sync/criticalsection.go
+++ b/src/sync/criticalsection.go
@@ -1,0 +1,33 @@
+package sync
+
+type CriticalSection struct {
+	mutex   *Mutex
+	state   uint32
+	entered bool
+}
+
+func NewCriticalSection(mutex *Mutex) CriticalSection {
+	return CriticalSection{
+		mutex: mutex,
+	}
+}
+
+func (c *CriticalSection) Begin() {
+	if !c.entered {
+		if c.mutex != nil {
+			c.mutex.Lock()
+		}
+		c.state = disableInterrupts()
+		c.entered = true
+	}
+}
+
+func (c *CriticalSection) End() {
+	if c.entered {
+		c.entered = false
+		if c.mutex != nil {
+			c.mutex.Unlock()
+		}
+		enableInterrupts(c.state)
+	}
+}

--- a/src/sync/interrupts.go
+++ b/src/sync/interrupts.go
@@ -1,0 +1,7 @@
+package sync
+
+//sigo:extern enableInterrupts runtime.EnableInterrupts
+//sigo:extern disableInterrupts runtime.DisableInterrupts
+
+func enableInterrupts(state uint32)
+func disableInterrupts() uint32

--- a/src/sync/mutex.go
+++ b/src/sync/mutex.go
@@ -6,13 +6,13 @@ type Mutex struct {
 	state uint32
 }
 
-//sigo:extern schedulerPause runtime.schedulerPause
-func schedulerPause()
+//sigo:extern gosched runtime.gosched
+func gosched()
 
 func (m *Mutex) Lock() {
 	for !atomic.CompareAndSwapUint32(&m.state, 0, 1) {
 		// Yield to run a different goroutine.
-		schedulerPause()
+		gosched()
 	}
 }
 


### PR DESCRIPTION
runtime:
Renamed `runtime.schedulerPause` to `runtime.gosched`. Renamed `runtime.runScheduler` to `runtime.schedule`. runtime.alloc uses `CriticalSection` to prevent improper handling of the mutex and interrupt enable/disable call ordering. Removed unnecessary critical sections within the GC implementation.

sync:
Implemented `CriticalSection` API to guarantee well-formed routines for when a mutex and interrupt disable/enable switches are used together in order to prevent deadlocks.