### PR TITLE
Bugfixes and improvements to code generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,4 +278,5 @@ tablegen-csp: $(TABLEGEN_CSP_EXE)
     	dlv --listen=:2346 --headless=true --api-version=2 --accept-multiclient exec $(TABLEGEN_CSP_EXE) -- $(args); \
 	fi
 
-release: generate-csp sigo
+release: sigo
+generate-bindings: generate-mlir-bindings generate-llvm-bindings

--- a/builder/package.go
+++ b/builder/package.go
@@ -465,7 +465,6 @@ func pkgCompilerRT(triplet string, features []string, floatEnabled bool) (Packag
 		"divti3.c",
 		"extendsfdf2.c",
 		"extendhfsf2.c",
-		"extendhfdf2.c",
 		"ffsdi2.c",
 		"ffssi2.c",
 		"ffsti2.c",

--- a/cmd/tablegen-csp/peripheral.go
+++ b/cmd/tablegen-csp/peripheral.go
@@ -132,11 +132,38 @@ func generateRegister(out io.Writer, register *tablegen.Record) (int, error) {
 		return 0, err
 	}
 
+	addr := fmt.Sprintf("(*%s)(r)", registerUnderlyingType)
+	load := fmt.Sprintf("volatile.LoadUint%d(%s)", registerWidth, addr)
+
 	if len(registerDescription) > 0 {
 		fmt.Fprintf(&builder, "// %s %s\n", registerTypeName, registerDescription)
 	}
 
 	fmt.Fprintf(&builder, "type %s %s\n\n", registerTypeName, registerUnderlyingType)
+
+	// Generate generic API.
+	fmt.Fprintf(&builder, "func (r *%s) Load() %s {\n", registerTypeName, registerUnderlyingType)
+	fmt.Fprintf(&builder, "return %s\n", load)
+	fmt.Fprintf(&builder, "}\n\n")
+
+	fmt.Fprintf(&builder, "func (r *%s) Store(value %s) {\n", registerTypeName, registerUnderlyingType)
+	fmt.Fprintf(&builder, "volatile.StoreUint%d(%s, value)\n", registerWidth, addr)
+	fmt.Fprintf(&builder, "}\n\n")
+
+	fmt.Fprintf(&builder, "func (r *%s) StoreBits(mask %s) {\n", registerTypeName, registerUnderlyingType)
+	fmt.Fprintf(&builder, "value := %s\n", load)
+	fmt.Fprintf(&builder, "volatile.StoreUint%d(%s, value|mask)\n", registerWidth, addr)
+	fmt.Fprintf(&builder, "}\n\n")
+
+	fmt.Fprintf(&builder, "func (r *%s) ClearBits(mask %s) {\n", registerTypeName, registerUnderlyingType)
+	fmt.Fprintf(&builder, "value := %s\n", load)
+	fmt.Fprintf(&builder, "volatile.StoreUint%d(%s, value &^ mask)\n", registerWidth, addr)
+	fmt.Fprintf(&builder, "}\n\n")
+
+	fmt.Fprintf(&builder, "func (r *%s) HasBits(mask %s) bool {\n", registerTypeName, registerUnderlyingType)
+	fmt.Fprintf(&builder, "value := %s\n", load)
+	fmt.Fprintf(&builder, "return value&mask != 0")
+	fmt.Fprintf(&builder, "}\n\n")
 
 	fields := register.GetValueAsListOfDefs(constRegisterFieldFields)
 	for _, field := range fields {
@@ -201,9 +228,6 @@ func generateRegister(out io.Writer, register *tablegen.Record) (int, error) {
 		fmt.Fprintf(&builder, "%s = %#x\n", constMask, mask)
 		fmt.Fprintf(&builder, ")\n\n")
 
-		addr := fmt.Sprintf("(*%s)(r)", registerUnderlyingType)
-		load := fmt.Sprintf("volatile.LoadUint%d(%s)", registerWidth, addr)
-
 		if strings.Contains(fieldAccess, "R") {
 			// Generate read API.
 			if len(fieldDescription) > 0 {
@@ -265,7 +289,7 @@ func formatRegisterTypeName(def *tablegen.Record) string {
 	registerName := def.GetValueAsString(constObjectFieldName)
 	registerName = formatCamelCase(strings.Split(registerName, "_")...)
 
-	return formatGoIdentifier(formatCamelCase("register", registerName, "Type"), false)
+	return formatGoIdentifier(formatCamelCase("register", registerName, "Type"), true)
 }
 
 func formatRegisterFieldEnumTypeName(register, field *tablegen.Record) string {

--- a/compiler/ssa/call.go
+++ b/compiler/ssa/call.go
@@ -235,7 +235,8 @@ func (b *Builder) emitCallExpr(ctx context.Context, expr *ast.CallExpr) []mlir.V
 				envPtr := resultOf(extractOp)
 
 				// Emit the indirect call.
-				op := mlir.GoCreateCallIndirectOperation(b.ctx, funcPtr, resultTypes, append(argValues, envPtr), location)
+				argValues = append([]mlir.Value{envPtr}, argValues...)
+				op := mlir.GoCreateCallIndirectOperation(b.ctx, funcPtr, resultTypes, argValues, location)
 				appendOperation(ctx, op)
 				return resultsOf(op)
 			default:

--- a/compiler/ssa/emit.go
+++ b/compiler/ssa/emit.go
@@ -283,9 +283,12 @@ func (b *Builder) emitBlock(ctx context.Context, stmt *ast.BlockStmt) {
 
 func (b *Builder) emitStatements(ctx context.Context, list []ast.Stmt) {
 	for _, stmt := range list {
-		// Do not continue emission if the current block is already terminated.
-		if blockHasTerminator(currentBlock(ctx)) {
-			return
+		// NOTE: Labeled blocks are allowed to follow a terminator.
+		if _, ok := stmt.(*ast.LabeledStmt); !ok {
+			// Do not emit into the current block if it is already terminated.
+			if blockHasTerminator(currentBlock(ctx)) {
+				continue
+			}
 		}
 
 		b.emitStmt(ctx, stmt)
@@ -306,7 +309,12 @@ func (b *Builder) emitBranchStatement(ctx context.Context, stmt *ast.BranchStmt)
 		appendOperation(ctx, brOp)
 		return
 	case token.GOTO:
-		block := currentLabeledBlocks(ctx)[stmt.Label.Name]
+		labeledBlocks := currentLabeledBlocks(ctx)
+		block, ok := labeledBlocks[stmt.Label.Name]
+		if !ok {
+			panic("no block with label " + stmt.Label.Name + " found")
+		}
+
 		brOp := mlir.GoCreateBranchOperation(b.ctx, block, nil, b.location(stmt.Pos()))
 		appendOperation(ctx, brOp)
 		return
@@ -525,7 +533,8 @@ func (b *Builder) emitIndexExpr(ctx context.Context, expr *ast.IndexExpr) []mlir
 	location := b.location(expr.Pos())
 
 	// Perform the specific index operation based on the input value type.
-	switch b.typeOf(ctx, expr.X).(type) {
+	T := baseType(b.typeOf(ctx, expr.X))
+	switch T.(type) {
 	case *types.Array:
 		// Evaluate the address.
 		addr := b.emitIndexAddr(ctx, expr)
@@ -596,9 +605,9 @@ func (b *Builder) emitIndexAddr(ctx context.Context, expr *ast.IndexExpr) mlir.V
 	index := b.emitExpr(ctx, expr.Index)[0]
 
 	// Perform the specific index operation based on the input value type.
-	switch baseType := b.typeOf(ctx, expr.X).(type) {
+	switch underlyingType := baseType(b.typeOf(ctx, expr.X)).(type) {
 	case *types.Array:
-		arrayT := b.GetType(ctx, baseType)
+		arrayT := b.GetType(ctx, underlyingType)
 
 		// Get the address of the array.
 		ptr := b.addressOf(ctx, expr.X, location)
@@ -715,13 +724,25 @@ func (b *Builder) emitReturn(ctx context.Context, stmt *ast.ReturnStmt) {
 }
 
 func (b *Builder) emitLabeledStatement(ctx context.Context, stmt *ast.LabeledStmt) {
-	// All labeled blocks should have been created prior. Simply just branch to it.
-	block := currentLabeledBlocks(ctx)[stmt.Label.Name]
-	brOp := mlir.GoCreateBranchOperation(b.ctx, block, nil, b.location(stmt.Pos()))
-	appendOperation(ctx, brOp)
+	curr := currentBlock(ctx)
+
+	// All labeled blocks should have been created prior.
+	labeledBlocks := currentLabeledBlocks(ctx)
+	block, ok := labeledBlocks[stmt.Label.Name]
+	if !ok {
+		panic("no block with label " + stmt.Label.Name + " found")
+	}
+
+	if !blockHasTerminator(curr) {
+		// Branch to the labeled block.
+		brOp := mlir.GoCreateBranchOperation(b.ctx, block, nil, b.location(stmt.Pos()))
+		appendOperation(ctx, brOp)
+	}
+
+	// Move block after current block.
+	mlir.GoMoveBlockAfter(block, curr)
 
 	// Continue emission in the labeled block.
-	appendBlock(ctx, block)
 	setCurrentBlock(ctx, block)
 
 	// Emit the labeled statement's statement

--- a/compiler/ssa/func.go
+++ b/compiler/ssa/func.go
@@ -233,14 +233,18 @@ func (b *Builder) emitFunc(ctx context.Context, data *funcData) {
 		}
 
 		// Create all labeled blocks before emitting the body since some statements might need to be able to look them
-		// up later. The ast.LabeledStmt will actually append them to the current region as the appropriate time.
+		// up later. The ast.LabeledStmt will actually append them to the current region at the appropriate time.
 		labeledBlocks := map[string]mlir.Block{}
-		for _, stmt := range data.body.List {
-			if stmt, ok := stmt.(*ast.LabeledStmt); ok {
+		ast.Inspect(data.body, func(node ast.Node) bool {
+			if stmt, ok := node.(*ast.LabeledStmt); ok {
 				labeledBlock := mlir.BlockCreate2(nil, nil)
 				labeledBlocks[stmt.Label.Name] = labeledBlock
+
+				// Append the block now.
+				appendBlock(ctx, labeledBlock)
 			}
-		}
+			return true
+		})
 		ctx = newContextWithLabeledBlocks(ctx, labeledBlocks)
 
 		// Fill the function body.

--- a/compiler/ssa/lit.go
+++ b/compiler/ssa/lit.go
@@ -35,8 +35,9 @@ func (b *Builder) emitCompositeLiteral(ctx context.Context, expr *ast.CompositeL
 
 func (b *Builder) emitArrayLiteral(ctx context.Context, expr *ast.CompositeLit) mlir.Value {
 	location := b.location(expr.Pos())
-	arrayType := b.typeOf(ctx, expr).Underlying().(*types.Array)
-	T := b.GetStoredType(ctx, arrayType)
+	litType := b.typeOf(ctx, expr)
+	arrayType := baseType(litType).(*types.Array)
+	T := b.GetStoredType(ctx, litType)
 
 	// Create the zero value of the array type.
 	zeroOp := mlir.GoCreateZeroOperation(b.ctx, T, location)
@@ -81,8 +82,9 @@ func (b *Builder) emitArrayLiteral(ctx context.Context, expr *ast.CompositeLit) 
 
 func (b *Builder) emitMapLiteral(ctx context.Context, expr *ast.CompositeLit) mlir.Value {
 	location := b.location(expr.Pos())
-	mapType := b.typeOf(ctx, expr).Underlying().(*types.Map)
-	mapT := b.GetStoredType(ctx, mapType)
+	litType := b.typeOf(ctx, expr)
+	mapType := baseType(litType).(*types.Map)
+	mapT := b.GetStoredType(ctx, litType)
 
 	// Emit the capacity value.
 	capacityVal := b.emitConstInt(ctx, int64(len(expr.Elts)), b.si, location)
@@ -145,9 +147,10 @@ func (b *Builder) emitMapLiteral(ctx context.Context, expr *ast.CompositeLit) ml
 
 func (b *Builder) emitSliceLiteral(ctx context.Context, expr *ast.CompositeLit) mlir.Value {
 	location := b.location(expr.Pos())
-	sliceType := b.typeOf(ctx, expr).Underlying().(*types.Slice)
+	litType := b.typeOf(ctx, expr)
+	sliceType := baseType(litType).(*types.Slice)
 	elementT := sliceType.Elem()
-	sliceT := b.GetStoredType(ctx, sliceType)
+	sliceT := b.GetStoredType(ctx, litType)
 
 	// Create the slice value.
 	lengthVal := b.emitConstInt(ctx, int64(len(expr.Elts)), b.si, location)
@@ -192,8 +195,9 @@ func (b *Builder) emitSliceLiteral(ctx context.Context, expr *ast.CompositeLit) 
 
 func (b *Builder) emitStructLiteral(ctx context.Context, expr *ast.CompositeLit) mlir.Value {
 	location := b.location(expr.Pos())
-	structType := b.typeOf(ctx, expr).Underlying().(*types.Struct)
-	structT := b.GetStoredType(ctx, b.typeOf(ctx, expr))
+	litType := b.typeOf(ctx, expr)
+	structType := baseType(litType).(*types.Struct)
+	structT := b.GetStoredType(ctx, litType)
 
 	// Create the zero value of the struct type.
 	zeroOp := mlir.GoCreateZeroOperation(b.ctx, structT, location)
@@ -268,37 +272,37 @@ func (b *Builder) emitFuncLiteral(ctx context.Context, expr *ast.FuncLit) mlir.V
 	enclosingData := currentFuncData(ctx)
 	info := currentInfo(ctx)
 	scope := info.Scopes[expr.Type]
-	signature := b.typeOf(ctx, expr).(*types.Signature)
+	originalSignature := b.typeOf(ctx, expr).(*types.Signature)
 
 	// Create a synthetic signature with the context pointer as the first parameter.
 	var recvTypeParams, typeParams []*types.TypeParam
 	var params, results []*types.Var
-	if signature.RecvTypeParams() != nil {
-		recvTypeParams = make([]*types.TypeParam, signature.RecvTypeParams().Len())
-		for i := 0; i < signature.RecvTypeParams().Len(); i++ {
-			recvTypeParams[i] = signature.RecvTypeParams().At(i)
+	if originalSignature.RecvTypeParams() != nil {
+		recvTypeParams = make([]*types.TypeParam, originalSignature.RecvTypeParams().Len())
+		for i := 0; i < originalSignature.RecvTypeParams().Len(); i++ {
+			recvTypeParams[i] = originalSignature.RecvTypeParams().At(i)
 		}
 	}
 
-	if signature.TypeParams() != nil {
-		typeParams = make([]*types.TypeParam, signature.TypeParams().Len())
-		for i := 0; i < signature.TypeParams().Len(); i++ {
-			typeParams[i] = signature.TypeParams().At(i)
+	if originalSignature.TypeParams() != nil {
+		typeParams = make([]*types.TypeParam, originalSignature.TypeParams().Len())
+		for i := 0; i < originalSignature.TypeParams().Len(); i++ {
+			typeParams[i] = originalSignature.TypeParams().At(i)
 		}
 	}
 
-	params = make([]*types.Var, signature.Params().Len()+1)
+	params = make([]*types.Var, originalSignature.Params().Len()+1)
 	params[0] = types.NewVar(token.NoPos, nil, "captures", types.Typ[types.UnsafePointer])
-	for i := 0; i < signature.Params().Len(); i++ {
-		params[i+1] = signature.Params().At(i)
+	for i := 0; i < originalSignature.Params().Len(); i++ {
+		params[i+1] = originalSignature.Params().At(i)
 	}
 
-	results = make([]*types.Var, signature.Results().Len())
-	for i := 0; i < signature.Results().Len(); i++ {
-		results[i] = signature.Results().At(i)
+	results = make([]*types.Var, originalSignature.Results().Len())
+	for i := 0; i < originalSignature.Results().Len(); i++ {
+		results[i] = originalSignature.Results().At(i)
 	}
 
-	signature = types.NewSignatureType(nil, recvTypeParams, typeParams, types.NewTuple(params...), types.NewTuple(results...), signature.Variadic())
+	signature := types.NewSignatureType(nil, recvTypeParams, typeParams, types.NewTuple(params...), types.NewTuple(results...), originalSignature.Variadic())
 	T := b.GetType(ctx, signature)
 
 	// Create the function data for the anonymous function.
@@ -332,47 +336,150 @@ func (b *Builder) emitFuncLiteral(ctx context.Context, expr *ast.FuncLit) mlir.V
 
 		// Find all free variables.
 		captures := map[types.Object]*FreeVar{}
-		for scope.Parent() != nil {
-			scope = scope.Parent()
-			for _, name := range scope.Names() {
-				capturedObj := scope.Lookup(name)
 
-				// Skip variables declared after this anonymous function.
-				if capturedObj.Pos() > expr.Pos() {
-					continue
+		// First track all variables declared locally in the anonymous function.
+		localObj := map[types.Object]struct{}{}
+		ast.Inspect(expr.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.GenDecl:
+				for _, spec := range node.Specs {
+					if vs, ok := spec.(*ast.ValueSpec); ok {
+						for _, name := range vs.Names {
+							if obj := b.objectOf(ctx, name); obj != nil {
+								localObj[obj] = struct{}{}
+							}
+						}
+					}
 				}
 
-				// Ignore some object types.
-				switch capturedObj.(type) {
-				case *types.PkgName:
-					continue
+			case *ast.FuncLit:
+				if node == expr { // only the current func
+					for _, field := range node.Type.Params.List {
+						for _, name := range field.Names {
+							if obj := b.objectOf(ctx, name); obj != nil {
+								localObj[obj] = struct{}{}
+							}
+						}
+					}
 				}
 
-				varType := b.GetStoredType(ctx, capturedObj.Type())
-				ptrType := mlir.GoCreatePointerType(varType)
-				allocType := mlir.GoCreatePointerType(ptrType)
-
-				// Create an allocation to hold the pointer to the variable in the outer scope.
-				// NOTE: The pointee should reside on the heap.
-				allocaOp := mlir.GoCreateAllocaOperation(b.ctx, allocType, ptrType, 1, false, b.location(scope.Pos()))
-
-				// Create a FreeVar.
-				fv := &FreeVar{
-					obj: capturedObj,
-					ptr: resultOf(allocaOp),
-					T:   varType,
-					b:   b,
+			case *ast.AssignStmt:
+				if node.Tok == token.DEFINE {
+					for _, lhs := range node.Lhs {
+						if ident, ok := lhs.(*ast.Ident); ok {
+							if obj := b.objectOf(ctx, ident); obj != nil {
+								localObj[obj] = struct{}{}
+							}
+						}
+					}
 				}
-				captures[capturedObj] = fv
-				anonData.freeVars = append(anonData.freeVars, fv)
-				anonData.locals[capturedObj] = fv
+			}
+			return true
+		})
+
+		// Collect all used identifiers inside the closure ignoring ones that are declared locally.
+		used := map[types.Object]bool{}
+		ast.Inspect(expr.Body, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if !ok || ident.Obj == nil {
+				return true
 			}
 
-			if scope == enclosingData.scope {
-				// Stop examining parent scopes.
-				break
+			obj := info.Uses[ident]
+			if obj == nil {
+				return true
 			}
+
+			// Skip if declared in the current function.
+			if _, ok := localObj[obj]; ok {
+				return true
+			}
+
+			// Skip parameters.
+			for v := range originalSignature.Params().Variables() {
+				if v == obj {
+					return true
+				}
+			}
+
+			// Skip package names, types, etc.
+			switch obj.(type) {
+			case *types.PkgName, *types.Func, *types.TypeName, *types.Const:
+				return true
+			}
+
+			// Don't double-count
+			if used[obj] {
+				return true
+			}
+
+			// This is a valid capture candidate.
+			used[obj] = true
+			return true
+		})
+
+		for obj := range used {
+			// You can skip this whole scope walk logic — the object already knows its scope.
+			varType := b.GetStoredType(ctx, obj.Type())
+			ptrType := mlir.GoCreatePointerType(varType)
+			allocType := mlir.GoCreatePointerType(ptrType)
+
+			allocaOp := mlir.GoCreateAllocaOperation(b.ctx, allocType, ptrType, 1, false, b.location(obj.Pos()))
+			fv := &FreeVar{
+				obj: obj,
+				ptr: resultOf(allocaOp),
+				T:   varType,
+				b:   b,
+			}
+
+			captures[obj] = fv
+			anonData.freeVars = append(anonData.freeVars, fv)
+			anonData.locals[obj] = fv
 		}
+
+		/*
+			for scope.Parent() != nil {
+				scope = scope.Parent()
+				for _, name := range scope.Names() {
+					capturedObj := scope.Lookup(name)
+
+					// Skip variables declared after this anonymous function.
+					if capturedObj.Pos() > expr.Pos() {
+						continue
+					}
+
+					// Ignore some object types.
+					switch capturedObj.(type) {
+					case *types.PkgName:
+						continue
+					}
+
+					varType := b.GetStoredType(ctx, capturedObj.Type())
+					ptrType := mlir.GoCreatePointerType(varType)
+					allocType := mlir.GoCreatePointerType(ptrType)
+
+					// Create an allocation to hold the pointer to the variable in the outer scope.
+					// NOTE: The pointee should reside on the heap.
+					allocaOp := mlir.GoCreateAllocaOperation(b.ctx, allocType, ptrType, 1, false, b.location(scope.Pos()))
+
+					// Create a FreeVar.
+					fv := &FreeVar{
+						obj: capturedObj,
+						ptr: resultOf(allocaOp),
+						T:   varType,
+						b:   b,
+					}
+					captures[capturedObj] = fv
+					anonData.freeVars = append(anonData.freeVars, fv)
+					anonData.locals[capturedObj] = fv
+				}
+
+				if scope == enclosingData.scope {
+					// Stop examining parent scopes.
+					break
+				}
+			}
+		*/
 	}
 
 	// Get and return the address of the function.

--- a/compiler/ssa/types.go
+++ b/compiler/ssa/types.go
@@ -48,6 +48,8 @@ func (b *Builder) GetType(ctx context.Context, T types.Type) (result mlir.Type) 
 	}
 
 	switch T := T.(type) {
+	case *types.Alias:
+		return b.GetType(ctx, types.Unalias(T))
 	case *types.Array:
 		result = b.createArrayType(ctx, T)
 	case *types.Basic:
@@ -450,6 +452,7 @@ func baseStructTypeOf(T types.Type) *types.Struct {
 }
 
 func baseType(T types.Type) types.Type {
+	T = types.Unalias(T)
 	for {
 		if named, ok := T.(*types.Named); ok {
 			T = named.Underlying()

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module pkg.si-go.dev/sigo
 
-go 1.22.0
-
-toolchain go1.23
+go 1.23.0
 
 require (
 	github.com/sirkon/go-format/v2 v2.0.2

--- a/goir/include/Go-c/mlir/Dialects.h
+++ b/goir/include/Go-c/mlir/Dialects.h
@@ -79,6 +79,8 @@ extern "C"
 
   void mlirGoBlockDumpTail(MlirBlock block, int count);
 
+  void mlirGoMoveBlockAfter(const MlirBlock block, const MlirBlock after);
+
   enum MlirGoAsmConstraintDirection
   {
     In,

--- a/goir/lib/CAPI/mlir/Dialects.cxx
+++ b/goir/lib/CAPI/mlir/Dialects.cxx
@@ -461,6 +461,13 @@ void mlirGoBlockDumpTail(MlirBlock block, int count)
   }
 }
 
+void mlirGoMoveBlockAfter(const MlirBlock block, const MlirBlock after)
+{
+  const auto _block = unwrap(block);
+  const auto _after = unwrap(after);
+  _block->moveBefore( _after->getParent(), std::next(_after->getIterator()));
+}
+
 MlirAttribute mlirGoCreateAsmConstraintAttr(
   MlirContext context,
   MlirStringRef registerClass,

--- a/goir/lib/Go/IR/Operations/Casting.cxx
+++ b/goir/lib/Go/IR/Operations/Casting.cxx
@@ -19,6 +19,11 @@ OpFoldResult BitcastOp::fold(FoldAdaptor adaptor)
   {
     return {};
   }
+
+  if (results.empty())
+  {
+    return {};
+  }
   return results.front();
 }
 

--- a/goir/lib/Go/Transforms/LowerToLLVM.cxx
+++ b/goir/lib/Go/Transforms/LowerToLLVM.cxx
@@ -1588,11 +1588,9 @@ struct GlobalCtorsOpLowering : ConvertOpToLLVMPattern<GlobalCtorsOp>
     OpAdaptor adaptor,
     ConversionPatternRewriter& rewriter) const override
   {
-    mlir::SmallVector<mlir::Attribute> data(
-      adaptor.getCtors().size(), mlir::LLVM::ZeroAttr::get(this->getContext()));
-    const auto dataAttr = mlir::ArrayAttr::get(this->getContext(), data);
     rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalCtorsOp>(
-      op, adaptor.getCtors(), adaptor.getPriorities(), dataAttr);
+      op, adaptor.getCtors(), adaptor.getPriorities());
+
     return success();
   }
 };

--- a/link.rsp
+++ b/link.rsp
@@ -34,7 +34,6 @@
 -lMLIRCAPIConversion
 -lMLIRCAPIDebug
 -lMLIRCAPIFunc
--lMLIRCAPIIndex
 -lMLIRCAPIInterfaces
 -lMLIRCAPIIR
 -lMLIRCAPIIRDL
@@ -48,7 +47,6 @@
 -lMLIRCAPIRegisterEverything
 -lMLIRCAPISCF
 -lMLIRCAPIShape
--lMLIRCAPISMT
 -lMLIRCAPISparseTensor
 -lMLIRCAPITensor
 -lMLIRCAPITransformDialect
@@ -57,7 +55,6 @@
 -lMLIRCAPIVector
 -lMLIRCastInterfaces
 -lMLIRComplexDialect
--lMLIRComplexDivisionConversion
 -lMLIRComplexToLLVM
 -lMLIRComplexToStandard
 -lMLIRControlFlowDialect
@@ -77,7 +74,6 @@
 -lMLIRDLTIDialect
 -lMLIRDLTITransformOps
 -lMLIRExecutionEngineUtils
--lMLIRExportSMTLIB
 -lMLIRFromLLVMIRTranslationRegistration
 -lMLIRFuncAllExtensions
 -lMLIRFuncDialect
@@ -156,7 +152,6 @@
 -lMLIRShapeToStandard
 -lMLIRShardingInterface
 -lMLIRSideEffectInterfaces
--lMLIRSMT
 -lMLIRSparseTensorDialect
 -lMLIRSparseTensorPipelines
 -lMLIRSparseTensorTransformOps

--- a/src/runtime/gc.go
+++ b/src/runtime/gc.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -239,14 +240,25 @@ func initgc() {
 
 //go:export alloc runtime.alloc
 func alloc(size uintptr) unsafe.Pointer {
+	var ptr unsafe.Pointer
+
+	if gc.phase != gcIdle {
+		// No need to lock during the sweep phase.
+		return _alloc(size)
+	}
+
 	criticalSection := sync.NewCriticalSection(&gc.mutex)
 	criticalSection.Begin()
+	ptr = _alloc(size)
+	criticalSection.End()
+	return ptr
+}
 
+func _alloc(size uintptr) unsafe.Pointer {
 	allocSize := gcObjectSize + size
 
 	ptr := malloc(allocSize)
 	if ptr == nil {
-		// Attempt to reclaim memory now.
 		gc.fullGC()
 		ptr = malloc(allocSize)
 		if ptr == nil {
@@ -255,18 +267,25 @@ func alloc(size uintptr) unsafe.Pointer {
 	}
 
 	obj := (*gcObject)(ptr)
-	obj.next = gc.head
-	// NOTE: Objects are born black to prevent sweeping them early.
 	obj.color = gcBlack
 	obj.size = size
-	gc.head = obj
 
 	if gc.phase == gcIdle {
-		// Transition to mark phase.
 		gc.startMark()
 	}
 
-	criticalSection.End()
+	for {
+		head := gc.head
+		obj.next = head
+		if atomic.CompareAndSwapPointer(
+			(*unsafe.Pointer)(unsafe.Pointer(&gc.head)),
+			unsafe.Pointer(head),
+			unsafe.Pointer(obj),
+		) {
+			break
+		}
+	}
+
 	return unsafe.Add(ptr, gcObjectSize)
 }
 


### PR DESCRIPTION
builder:
Removed compilerRT source that doesn't exist in LLVM 20.

tablegen-csp:
Each register now will have a generic API generated for it to set the entire value or bits.

compiler/ssa:
Fixed bugs with indirect calls to anonymous functions where the context pointer parameter was passed as the last parameter instead of the first. Fixed bug with label statements where their contents was not being generated because a previous block already terminated the function. Implemented a better method for finding label statements using ast.Inspect to fix a bug where nested label statements were not being seen. Fixed bug with index expressions where the underlying type of the input value was not being identified properly. Fixed bug with literal expressions where the incorrect result type was used. Implemented an improved method of detecting capture variables of function literals based on ast.Inspect that is far less aggressive and captures only the outer variables that are actually used in within the body of the literal function. Type aliases are now properly handled in type system translations.

goir:
Implemented API to move a block.
Fixed a bug in the folding logic of the bitcast operation where it didn't consider a success fold of its value's defining operation yielding an empty fold result. Rolled back usage of mlir::LLVM::GlobalCtorsOp to match that of LLVM 20.

runtime:
Improvements to garbage collector implementation to allow heap allocations from an ISR without risk of deadlock.

thirdparty:
Rolled LLVM back to version 20.1.7

other:
Raised minimum required Go version for the compiler to 1.23.0 to allow for usage of iterators within the SSA builder.