### PR TITLE
Fix bug where generic type methods where not generated.

### DIFF
--- a/compiler/ssa/builder.go
+++ b/compiler/ssa/builder.go
@@ -576,7 +576,7 @@ func (b *Builder) addFunctionDecl(ctx context.Context, decl *ast.FuncDecl) *func
 		symbol = mangleSymbol("main.main")
 	}
 
-	signature := obj.Type().Underlying().(*types.Signature)
+	signature := baseType(obj.Type()).(*types.Signature)
 	symbolInfo := b.config.Program.Symbols.GetSymbolInfo(symbol)
 	actualSymbol := b.resolveSymbol(symbol)
 

--- a/compiler/ssa/call.go
+++ b/compiler/ssa/call.go
@@ -46,6 +46,21 @@ func (b *Builder) emitCallExpr(ctx context.Context, expr *ast.CallExpr) []mlir.V
 		case *ast.SelectorExpr:
 			T := b.typeOf(ctx, Fun.X)
 			obj := b.objectOf(ctx, Fun.Sel)
+
+			if paramT, ok := T.(*types.TypeParam); ok {
+				data := currentFuncData(ctx)
+				namedT := data.typeMap[paramT.Index()].(*types.Named)
+				T = namedT
+
+				// Lookup the actual function being called.
+				for method := range namedT.Methods() {
+					if method.Name() == obj.Name() {
+						obj = method
+						break
+					}
+				}
+			}
+
 			switch T.Underlying().(type) {
 			case *types.Interface:
 				funcObj := obj.(*types.Func)
@@ -64,7 +79,7 @@ func (b *Builder) emitCallExpr(ctx context.Context, expr *ast.CallExpr) []mlir.V
 					fobj := b.objectOf(ctx, expr.Fun)
 					signature = baseType(fobj.Type()).(*types.Signature)
 				}
-				//signature := obj.Type().(*types.Signature)
+
 				if signature.Recv() != nil {
 					recvType := signature.Recv().Type()
 					actualRecvType := b.typeOf(ctx, Fun.X)
@@ -331,7 +346,12 @@ func (b *Builder) emitGeneralCall(ctx context.Context, ident *ast.Ident, obj *ty
 	// Is the callee a generic function?
 	if signature.TypeParams().Len() > 0 || signature.RecvTypeParams().Len() > 0 {
 		// Need to instantiate this generic function.
-		data := b.genericFuncs[callee]
+		data, ok := b.genericFuncs[callee]
+		if !ok {
+			decl := b.ungeneratedFuncs[callee]
+			data = b.addFunctionDecl(ctx, decl)
+		}
+
 		instance := info.Instances[ident]
 		instanceData := b.createFuncInstance(ctx, signature, instance, data)
 		callee = instanceData.linkname

--- a/compiler/ssa/func.go
+++ b/compiler/ssa/func.go
@@ -323,8 +323,20 @@ func (b *Builder) createFuncInstance(ctx context.Context, genericSignature *type
 	// Map the receiver type parameter to the concrete receiver type.
 	if recv := genericSignature.Recv(); recv != nil {
 		signature = genericSignature
-		targs := signature.Recv().Type().(*types.Named).TypeArgs()
-		tparams := signature.Recv().Type().(*types.Named).TypeParams()
+
+		// Determine the underlying named type.
+		var namedType *types.Named
+		switch T := types.Unalias(signature.Recv().Type()).(type) {
+		case *types.Pointer:
+			namedType = T.Elem().(*types.Named)
+		case *types.Named:
+			namedType = T
+		default:
+			panic("unhandled")
+		}
+
+		targs := namedType.TypeArgs()
+		tparams := namedType.TypeParams()
 		for i := 0; i < targs.Len(); i++ {
 			typeMap[tparams.At(i).Index()] = targs.At(i)
 		}
@@ -361,8 +373,7 @@ func (b *Builder) createFuncInstance(ctx context.Context, genericSignature *type
 	}
 
 	// Create the instantiated function type.
-	ctx = newContextWithFuncData(ctx, instanceData)
-	instanceData.mlirType = b.createSignatureType(ctx, signature)
+	instanceData.mlirType = b.createSignatureType(newContextWithFuncData(ctx, instanceData), signature)
 
 	// Emit the instance.
 	b.emitFunc(ctx, instanceData)

--- a/compiler/ssa/lit.go
+++ b/compiler/ssa/lit.go
@@ -436,50 +436,6 @@ func (b *Builder) emitFuncLiteral(ctx context.Context, expr *ast.FuncLit) mlir.V
 			anonData.freeVars = append(anonData.freeVars, fv)
 			anonData.locals[obj] = fv
 		}
-
-		/*
-			for scope.Parent() != nil {
-				scope = scope.Parent()
-				for _, name := range scope.Names() {
-					capturedObj := scope.Lookup(name)
-
-					// Skip variables declared after this anonymous function.
-					if capturedObj.Pos() > expr.Pos() {
-						continue
-					}
-
-					// Ignore some object types.
-					switch capturedObj.(type) {
-					case *types.PkgName:
-						continue
-					}
-
-					varType := b.GetStoredType(ctx, capturedObj.Type())
-					ptrType := mlir.GoCreatePointerType(varType)
-					allocType := mlir.GoCreatePointerType(ptrType)
-
-					// Create an allocation to hold the pointer to the variable in the outer scope.
-					// NOTE: The pointee should reside on the heap.
-					allocaOp := mlir.GoCreateAllocaOperation(b.ctx, allocType, ptrType, 1, false, b.location(scope.Pos()))
-
-					// Create a FreeVar.
-					fv := &FreeVar{
-						obj: capturedObj,
-						ptr: resultOf(allocaOp),
-						T:   varType,
-						b:   b,
-					}
-					captures[capturedObj] = fv
-					anonData.freeVars = append(anonData.freeVars, fv)
-					anonData.locals[capturedObj] = fv
-				}
-
-				if scope == enclosingData.scope {
-					// Stop examining parent scopes.
-					break
-				}
-			}
-		*/
 	}
 
 	// Get and return the address of the function.

--- a/compiler/ssa/types.go
+++ b/compiler/ssa/types.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"hash/fnv"
 
 	"pkg.si-go.dev/sigo/mlir"
 )
@@ -217,21 +216,16 @@ func (b *Builder) createNamedType(ctx context.Context, T *types.Named) mlir.Type
 	// Format the qualified identifier for this type with respect to its origin package.
 	identifier := qualifiedName(T.Obj().Name(), T.Obj().Pkg())
 
-	if T.TypeArgs().Len() > 0 {
-		hasher := fnv.New32()
-		hasher.Write([]byte(T.Obj().Name()))
-		for i := 0; i < T.TypeArgs().Len(); i++ {
-			hasher.Write([]byte(T.TypeArgs().At(i).String()))
-		}
-		hasher.Sum32()
-		identifier += fmt.Sprintf("$%X", hasher.Sum32())
-	}
-
 	// Add the identifier to the current context.
 	ctx = newContextWithIdentifier(ctx, identifier)
 
 	// Create the underlying type.
 	underlyingType := b.GetType(ctx, T.Underlying())
+	underlyingTypeHash := mlir.TypeHash(underlyingType)
+
+	if T.TypeArgs().Len() > 0 {
+		identifier += fmt.Sprintf("$%X", underlyingTypeHash)
+	}
 
 	// Collect method symbols.
 	entries := make([]mlir.Attribute, T.NumMethods())


### PR DESCRIPTION
compiler/ssa:
The type parameters are now properly evaluated when generating SSA for generic type method calls. Fixed bug where the generic receiver type was not being determined properly. Fixed bug where the identifier for named types were not being generated consistently resulting in type mismatches solely on the type's name even though the underlying type is identical.