### PR TITLE
Refactor mutex to use a ticketing mechanism to reduce lock contention.

### DIFF
--- a/goir/lib/Go/Transforms/LowerToLLVM.cxx
+++ b/goir/lib/Go/Transforms/LowerToLLVM.cxx
@@ -355,12 +355,25 @@ struct AtomicAddIOpLowering : ConvertOpToLLVMPattern<AtomicAddIOp>
     OpAdaptor adaptor,
     ConversionPatternRewriter& rewriter) const override
   {
-    rewriter.replaceOpWithNewOp<mlir::LLVM::AtomicRMWOp>(
-      op,
+    const auto loc = op.getLoc();
+    const auto resultType = adaptor.getRhs().getType();
+
+    mlir::Value oldValue = rewriter.create<mlir::LLVM::AtomicRMWOp>(
+      loc,
       mlir::LLVM::AtomicBinOp::add,
       adaptor.getAddr(),
       adaptor.getRhs(),
       mlir::LLVM::AtomicOrdering::acq_rel);
+
+    // NOTE: LLVM's AtomicRMW will yield the old value BEFORE the addition while Go's atomic.AddxInt
+    //       API expects the new value to be returned.
+
+    // Add the delta to the old value.
+    mlir::Value newValue =
+      rewriter.create<mlir::LLVM::AddOp>(loc, resultType, oldValue, adaptor.getRhs());
+
+    // Use the new value as the result.
+    rewriter.replaceOp(op, newValue);
     return success();
   }
 };

--- a/src/sync/mutex.go
+++ b/src/sync/mutex.go
@@ -1,25 +1,72 @@
 package sync
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+	"unsafe"
+)
 
 type Mutex struct {
-	state uint32
+	next   uint32
+	owner  uint32
+	ownerg unsafe.Pointer
 }
 
 //sigo:extern gosched runtime.gosched
 func gosched()
 
 func (m *Mutex) Lock() {
-	for !atomic.CompareAndSwapUint32(&m.state, 0, 1) {
+	currg := getg()
+	ownerg := atomic.LoadPointer(&m.ownerg)
+
+	// Detect recursive locking (non-reentrant).
+	if (currg == nil && ownerg != nil) || (currg != nil && ownerg == currg) {
+		panic("sync.Mutex: double lock by same goroutine")
+	}
+
+	// Get a ticket for the current goroutine.
+	ticket := atomic.AddUint32(&m.next, 1) - 1
+
+	// Wait until it's this goroutine's turn to acquire the lock.
+	for atomic.LoadUint32(&m.owner) != ticket {
 		// Yield to run a different goroutine.
 		gosched()
 	}
+
+	// The current goroutine will own the lock.
+	atomic.StorePointer(&m.ownerg, currg)
 }
 
 func (m *Mutex) TryLock() bool {
-	return atomic.CompareAndSwapUint32(&m.state, 0, 1)
+	owner := atomic.LoadUint32(&m.owner)
+	if atomic.LoadUint32(&m.next) != owner {
+		// The lock is already acquired.
+		return false
+	}
+
+	// Attempt to claim the next ticket.
+	if !atomic.CompareAndSwapUint32(&m.next, owner, owner+1) {
+		return false
+	}
+
+	// The current goroutine will own the lock.
+	atomic.StorePointer(&m.ownerg, getg())
+	return true
 }
 
 func (m *Mutex) Unlock() {
-	atomic.StoreUint32(&m.state, 0)
+	if atomic.LoadUint32(&m.owner) == atomic.LoadUint32(&m.next) {
+		// No one holds the lock (no outstanding ticket == owner).
+		panic("sync.Mutex: unlock of unlocked mutex")
+	}
+
+	// The lock can only be unlocked by the original owner. Check this first!
+	if atomic.LoadPointer(&m.ownerg) != getg() {
+		panic("sync.Mutex: unlock by non-owner")
+	}
+
+	// Free the lock from the current owner.
+	atomic.StorePointer(&m.ownerg, nil)
+
+	// Hand off to the next ticket holder (FIFO).
+	atomic.AddUint32(&m.owner, 1)
 }


### PR DESCRIPTION
The previous implementation favored faster goroutines which allow slower goroutines to be starved by lock contention. The new implementation uses a simple ticketing mechanism to guarantee that another goroutine waiting on the lock is allowed to acquire the lock when the lock is released.

goir:
Refactored `AtomicAddIOp` lowering to yield the new value (Go's expectation) instead of the old one (LLVM's behavior).

sync:
Implemented ticketing mechanism in mutex.
Added double-lock and double-free panics to mutex implementation. Added panic when mutex is attempted to be unlocked by a goroutine other than the one that originally acquired its lock.